### PR TITLE
Update settings and capabilities parsing and add a few commands

### DIFF
--- a/lib/include/capabilities.hpp
+++ b/lib/include/capabilities.hpp
@@ -3,16 +3,75 @@
 
 #include <stdint.h>
 #include <string>
+#include <vector>
+#include <map>
 
 namespace fcwt {
 
-const uint16_t capability_max_modes = 32;
+const uint16_t capability_max_values = 32;
+
+enum property_codes {
+  property_white_balance         = 0x5005,
+  property_aperture              = 0x5007,
+  property_focus_mode            = 0x500a,
+  property_shooting_mode         = 0x500e,
+  property_flash                 = 0x500c,
+  property_exposure_compensation = 0x5010,
+  property_self_timer            = 0x5012,
+  property_film_simulation       = 0xd001,
+  property_image_format          = 0xd018,
+  property_recmode_enable        = 0xd019,
+  property_shutter_type          = 0xd028,
+  property_iso                   = 0xd02a,
+  property_movie_iso             = 0xd02b,
+  property_focus_point           = 0xd17c,
+  property_focus_lock            = 0xd209,
+  property_device_error          = 0xd21b,
+  property_image_space_sd        = 0xd229,
+  property_movie_remaining_time  = 0xd22a,
+  property_shutter_speed         = 0xd240,
+  property_image_aspect          = 0xd241,
+  property_battery_level         = 0xd242,
+  property_unknown
+};
+
+static std::map<property_codes, const char *> property_strings = {
+   {property_white_balance, "White Balance"},
+   {property_aperture, "Aperture"},
+   {property_focus_mode, "Focus Mode"},
+   {property_shooting_mode, "Shooting Mode"},
+   {property_flash, "Flash"},
+   {property_exposure_compensation, "Exposure Compensation"},
+   {property_self_timer, "Self Timer"},
+   {property_film_simulation, "Film Simulation"},
+   {property_image_format, "Image Format"},
+   {property_recmode_enable, "Recording Mode"},
+   {property_shutter_type, "Shutter Type"},
+   {property_iso, "ISO"},
+   {property_movie_iso, "Movie ISO"},
+   {property_focus_point, "Focus Point"},
+   {property_focus_lock, "Focus Lock"},
+   {property_device_error, "Device Error"},
+   {property_image_space_sd, "Image Space on SD"},
+   {property_movie_remaining_time, "Movie Time Remaining"},
+   {property_shutter_speed, "Shutter Speed"},
+   {property_image_aspect, "Image Aspect"},
+   {property_battery_level, "Battery Level"},
+   {property_unknown, "Unknown Property"}
+};
 
 struct capability {
+  property_codes property_code = property_unknown;
+  uint16_t data_type = 0;
+  uint8_t get_set = 0;
+  uint32_t default_value = 0;
+  uint32_t current_value = 0;
+  uint8_t form_flag = 0;
   uint32_t min_value = 0;
-  uint32_t value = 0;
+  uint32_t max_value = 0;
+  uint32_t step_size = 0;
   uint16_t count = 0;
-  uint32_t modes[capability_max_modes] = {0};
+  uint32_t values[capability_max_values] = {0};
 };
 
 struct aperture_f_number {
@@ -21,24 +80,7 @@ struct aperture_f_number {
 
 std::string to_string(aperture_f_number aperture);
 
-struct auto_focus_caps {
-  // TODO
-};
-
-struct camera_capabilities {
-  auto_focus_caps auto_focus;
-  capability iso;
-  capability shutter;
-  capability aperture;
-  capability flash;
-  capability white_balance;
-  capability film_simulation;
-  capability recording;
-  capability self_timer;
-  capability exposure_compensation;
-};
-
-void print(camera_capabilities const& caps);
+void print(std::vector<capability> const& caps);
 
 }  // namespace fcwt
 

--- a/lib/include/capabilities.hpp
+++ b/lib/include/capabilities.hpp
@@ -6,10 +6,13 @@
 
 namespace fcwt {
 
+const uint16_t capability_max_modes = 32;
+const uint32_t iso_max_modes = 32;
 const uint32_t iso_flag_auto = 1 << 31;
 const uint32_t iso_flag_emulated = 1 << 30;
 const uint32_t iso_value_mask = 0x00ffffff;
-const uint32_t iso_max_levels = 32;
+const uint32_t shutter_flag_subsecond = 1 << 31;
+const uint32_t shutter_value_mask = 0x0fffffff;
 
 struct iso_level {
   iso_level(uint32_t val) : value(val) {}
@@ -20,16 +23,15 @@ struct iso_level {
 std::string to_string(iso_level iso);
 
 struct iso_levels {
-  uint32_t levels[iso_max_levels] = {};
-  uint32_t numLevels = 0;
+  uint32_t modes[capability_max_modes] = {};
+  uint32_t count = 0;
 };
 
-enum shutter_speed_mode { shutter_speed_auto, shutter_speed_manual };
-
-struct shutter_speed_parameters {
-  shutter_speed_mode mode = shutter_speed_auto;
+struct capability {
+  uint32_t min_value = 0;
   uint32_t value = 0;
-  int32_t exposure = 0;
+  uint16_t count = 0;
+  uint32_t modes[capability_max_modes] = {0};
 };
 
 struct aperture_f_number {
@@ -44,9 +46,15 @@ struct auto_focus_caps {
 
 struct camera_capabilities {
   iso_levels iso;
-  shutter_speed_parameters shutter_speed;
   auto_focus_caps auto_focus;
-  aperture_f_number aperture;
+  capability shutter;
+  capability aperture;
+  capability flash;
+  capability white_balance;
+  capability film_simulation;
+  capability recording;
+  capability self_timer;
+  capability exposure_compensation;
 };
 
 void print(camera_capabilities const& caps);

--- a/lib/include/capabilities.hpp
+++ b/lib/include/capabilities.hpp
@@ -10,7 +10,7 @@ namespace fcwt {
 
 const uint16_t capability_max_values = 32;
 
-enum property_codes {
+enum property_codes: uint16_t {
   property_white_balance         = 0x5005,
   property_aperture              = 0x5007,
   property_focus_mode            = 0x500a,
@@ -21,7 +21,7 @@ enum property_codes {
   property_film_simulation       = 0xd001,
   property_image_format          = 0xd018,
   property_recmode_enable        = 0xd019,
-  property_shutter_type          = 0xd028,
+  property_f_ss_control          = 0xd028,
   property_iso                   = 0xd02a,
   property_movie_iso             = 0xd02b,
   property_focus_point           = 0xd17c,
@@ -46,7 +46,7 @@ static std::map<property_codes, const char *> property_strings = {
    {property_film_simulation, "Film Simulation"},
    {property_image_format, "Image Format"},
    {property_recmode_enable, "Recording Mode"},
-   {property_shutter_type, "Shutter Type"},
+   {property_f_ss_control, "Aperture/ShutterSpeed ctrl"},
    {property_iso, "ISO"},
    {property_movie_iso, "Movie ISO"},
    {property_focus_point, "Focus Point"},
@@ -57,7 +57,7 @@ static std::map<property_codes, const char *> property_strings = {
    {property_shutter_speed, "Shutter Speed"},
    {property_image_aspect, "Image Aspect"},
    {property_battery_level, "Battery Level"},
-   {property_unknown, "Unknown Property"}
+   {property_unknown, "== Unknown Property =="}
 };
 
 struct capability {
@@ -73,12 +73,6 @@ struct capability {
   uint16_t count = 0;
   uint32_t values[capability_max_values] = {0};
 };
-
-struct aperture_f_number {
-  uint32_t value = 0;
-};
-
-std::string to_string(aperture_f_number aperture);
 
 void print(std::vector<capability> const& caps);
 

--- a/lib/include/capabilities.hpp
+++ b/lib/include/capabilities.hpp
@@ -7,25 +7,6 @@
 namespace fcwt {
 
 const uint16_t capability_max_modes = 32;
-const uint32_t iso_max_modes = 32;
-const uint32_t iso_flag_auto = 1 << 31;
-const uint32_t iso_flag_emulated = 1 << 30;
-const uint32_t iso_value_mask = 0x00ffffff;
-const uint32_t shutter_flag_subsecond = 1 << 31;
-const uint32_t shutter_value_mask = 0x0fffffff;
-
-struct iso_level {
-  iso_level(uint32_t val) : value(val) {}
-  operator uint32_t() const { return value; }
-  uint32_t value;
-};
-
-std::string to_string(iso_level iso);
-
-struct iso_levels {
-  uint32_t modes[capability_max_modes] = {};
-  uint32_t count = 0;
-};
 
 struct capability {
   uint32_t min_value = 0;
@@ -45,8 +26,8 @@ struct auto_focus_caps {
 };
 
 struct camera_capabilities {
-  iso_levels iso;
   auto_focus_caps auto_focus;
+  capability iso;
   capability shutter;
   capability aperture;
   capability flash;

--- a/lib/include/commands.hpp
+++ b/lib/include/commands.hpp
@@ -22,14 +22,19 @@ bool shutter(native_socket const sockfd, native_socket const sockfd2, const char
 
 bool current_settings(native_socket sockfd, camera_settings& settings);
 
-enum aperture_f_stop {
-    aperture_open_third_stop,
-    aperture_close_third_stop
+enum fnumber_update_direction {
+    fnumber_increment,
+    fnumber_decrement
 };
 
-enum shutter_speed_stop {
-	shutter_speed_one_stop_faster,
-	shutter_speed_one_stop_slower
+enum ss_update_direction {
+    ss_increment,
+    ss_decrement
+};
+
+enum exp_update_direction {
+    exp_increment,
+    exp_decrement
 };
 
 bool update_setting(native_socket sockfd, iso_level iso);
@@ -37,8 +42,11 @@ bool update_setting(native_socket sockfd, image_settings image);
 bool update_setting(native_socket sockfd, film_simulation_mode film);
 bool update_setting(native_socket sockfd, auto_focus_point point);
 bool update_setting(native_socket sockfd, white_balance_mode white_balance);
-bool update_setting(native_socket sockfd, aperture_f_stop aperture);
-bool update_setting(native_socket sockfd, shutter_speed_stop shutter_speed);
+bool update_setting(native_socket sockfd, flash_mode flash);
+bool update_setting(native_socket sockfd, timer_mode timer);
+bool update_setting(native_socket sockfd, fnumber_update_direction dir);
+bool update_setting(native_socket sockfd, ss_update_direction dir);
+bool update_setting(native_socket sockfd, exp_update_direction dir);
 
 }  // namespace fcwt
 

--- a/lib/include/commands.hpp
+++ b/lib/include/commands.hpp
@@ -20,7 +20,7 @@ void terminate_control_connection(native_socket sockfd);
 
 bool shutter(native_socket const sockfd, native_socket const sockfd2, const char* thumbnail = 0);
 
-bool current_settings(native_socket sockfd, camera_settings& settings);
+bool current_settings(native_socket sockfd, std::map<property_codes, uint32_t>& settings);
 
 enum fnumber_update_direction {
     fnumber_increment,
@@ -37,13 +37,8 @@ enum exp_update_direction {
     exp_decrement
 };
 
-bool update_setting(native_socket sockfd, iso_level iso);
-bool update_setting(native_socket sockfd, image_settings image);
-bool update_setting(native_socket sockfd, film_simulation_mode film);
+bool update_setting(native_socket sockfd, property_codes code, uint32_t value);
 bool update_setting(native_socket sockfd, auto_focus_point point);
-bool update_setting(native_socket sockfd, white_balance_mode white_balance);
-bool update_setting(native_socket sockfd, flash_mode flash);
-bool update_setting(native_socket sockfd, timer_mode timer);
 bool update_setting(native_socket sockfd, fnumber_update_direction dir);
 bool update_setting(native_socket sockfd, ss_update_direction dir);
 bool update_setting(native_socket sockfd, exp_update_direction dir);

--- a/lib/include/commands.hpp
+++ b/lib/include/commands.hpp
@@ -47,6 +47,7 @@ bool update_setting(native_socket sockfd, timer_mode timer);
 bool update_setting(native_socket sockfd, fnumber_update_direction dir);
 bool update_setting(native_socket sockfd, ss_update_direction dir);
 bool update_setting(native_socket sockfd, exp_update_direction dir);
+bool unlock_focus(native_socket sockfd);
 
 }  // namespace fcwt
 

--- a/lib/include/commands.hpp
+++ b/lib/include/commands.hpp
@@ -20,7 +20,7 @@ void terminate_control_connection(native_socket sockfd);
 
 bool shutter(native_socket const sockfd, native_socket const sockfd2, const char* thumbnail = 0);
 
-bool current_settings(native_socket sockfd, std::map<property_codes, uint32_t>& settings);
+bool current_settings(native_socket sockfd, current_properties& settings);
 
 enum fnumber_update_direction {
     fnumber_increment,

--- a/lib/include/commands.hpp
+++ b/lib/include/commands.hpp
@@ -15,7 +15,7 @@
 namespace fcwt {
 
 bool init_control_connection(native_socket sockfd, char const* deviceName,
-                             camera_capabilities* caps);
+                             std::vector<capability>* caps);
 void terminate_control_connection(native_socket sockfd);
 
 bool shutter(native_socket const sockfd, native_socket const sockfd2, const char* thumbnail = 0);

--- a/lib/include/log.hpp
+++ b/lib/include/log.hpp
@@ -6,12 +6,6 @@
 
 #include "platform.hpp"
 
-#define LOG_INFO(str) printf("[INFO] " str "\n")
-#define LOG_INFO_FORMAT(fmt, ...) printf("[INFO] " fmt "\n", __VA_ARGS__)
-
-#define LOG_WARN(str) printf("[WARNING] " str "\n")
-#define LOG_WARN_FORMAT(fmt, ...) printf("[WARNING] " fmt "\n", __VA_ARGS__)
-
 namespace fcwt {
 
 const uint8_t LOG_ERROR = 1;

--- a/lib/include/log.hpp
+++ b/lib/include/log.hpp
@@ -12,6 +12,7 @@ const uint8_t LOG_ERROR = 1;
 const uint8_t LOG_WARN = 2;
 const uint8_t LOG_INFO = 3;
 const uint8_t LOG_DEBUG = 4;
+const uint8_t LOG_DEBUG2 = 5;
 
 const uint8_t LOG_STDOUT = 1;
 const uint8_t LOG_FILE = 2;

--- a/lib/include/log.hpp
+++ b/lib/include/log.hpp
@@ -27,7 +27,7 @@ struct log_settings {
     uint8_t output = LOG_STDOUT;
 };
 
-void log(uint8_t level, char const* msg);
+void log(uint8_t level, std::string msg);
 
 enum append_newline { skip_newline, newline };
 

--- a/lib/include/log.hpp
+++ b/lib/include/log.hpp
@@ -21,6 +21,7 @@ struct log_settings {
     uint8_t level = LOG_DEBUG;
     uint8_t output = LOG_STDOUT;
 };
+extern log_settings log_conf;
 
 void log(uint8_t level, std::string msg);
 

--- a/lib/include/log.hpp
+++ b/lib/include/log.hpp
@@ -14,6 +14,21 @@
 
 namespace fcwt {
 
+const uint8_t LOG_ERROR = 1;
+const uint8_t LOG_WARN = 2;
+const uint8_t LOG_INFO = 3;
+const uint8_t LOG_DEBUG = 4;
+
+const uint8_t LOG_STDOUT = 1;
+const uint8_t LOG_FILE = 2;
+
+struct log_settings {
+    uint8_t level = LOG_DEBUG;
+    uint8_t output = LOG_STDOUT;
+};
+
+void log(uint8_t level, char const* msg);
+
 enum append_newline { skip_newline, newline };
 
 void print_hex(void const* data, size_t const sizeBytes,

--- a/lib/include/log.hpp
+++ b/lib/include/log.hpp
@@ -31,8 +31,8 @@ void log(uint8_t level, char const* msg);
 
 enum append_newline { skip_newline, newline };
 
-void print_hex(void const* data, size_t const sizeBytes,
-               append_newline anl = newline);
+std::string hex_format(void const* data, size_t const sizeBytes);
+
 void print_ascii(void const* data, size_t const sizeBytes,
                  append_newline anl = newline);
 void print_uint32(void const* data, size_t const sizeBytes,

--- a/lib/include/message.hpp
+++ b/lib/include/message.hpp
@@ -26,7 +26,7 @@ enum class message_type : uint16_t {
 
   camera_last_image = 0x9022,
   focus_point = 0x9026,    // updating focus point position
-  focus_lock = 0x9027,     // lock/unlock the current focus point
+  focus_unlock = 0x9027,   // unlock the current focus point
   camera_capabilities = 0x902b,  // unknown, app uses it before camera_remote,
                              // returns 392 bytes of data, maybe the current
                              // settings?
@@ -82,6 +82,8 @@ void fuji_send(native_socket sockfd, static_message<N> const& msg) {
 }
 
 inline void fuji_send(native_socket sockfd, message_header const& msg) {
+  std::string log_msg = string_format("send: %s(%d) ", to_string(msg.type), static_cast<int>(msg.type));
+  log(LOG_DEBUG, log_msg.append(hex_format(&msg, sizeof(message_header))));
   fuji_send(sockfd, &msg, sizeof(message_header));
 }
 

--- a/lib/include/message.hpp
+++ b/lib/include/message.hpp
@@ -25,11 +25,14 @@ enum class message_type : uint16_t {
   camera_remote = 0x101c,  // last command before camera remote works
 
   camera_last_image = 0x9022,
+  focus_point = 0x9026,    // updating focus point position
+  focus_lock = 0x9027,     // lock/unlock the current focus point
   camera_capabilities = 0x902b,  // unknown, app uses it before camera_remote,
                              // returns 392 bytes of data, maybe the current
                              // settings?
-  aperture = 0x902d, // relative adjustement of aperature by one third stop
   shutter_speed = 0x902c, // relative adjustment of sutter speed
+  aperture = 0x902d, // relative adjustement of aperature by one third stop
+  exposure_correction = 0x902e, // relative adjustment of exposure correction
 };
 
 char const* to_string(message_type type);

--- a/lib/include/message.hpp
+++ b/lib/include/message.hpp
@@ -61,28 +61,20 @@ struct static_message : message_header,
 
 uint32_t generate_message_id();
 
-template <size_t N>
-void print_message(static_message<N> const& msg, append_newline anl = newline) {
-  printf("%s(%d) [", to_string(msg.type), static_cast<int>(msg.type));
-  print_hex(&msg, msg.size(), skip_newline);
-  printf("]");
-  if (anl == newline) printf("\n");
-}
-
 bool fuji_message(native_socket const sockfd, uint32_t const id, void const* message,
                   size_t size);
 
 template <size_t N>
 bool fuji_message(native_socket const sockfd, const static_message<N>& msg) {
-  printf("send: ");
-  print_message(msg);
+  std::string log_msg = string_format("send: %s(%d) ", to_string(msg.type), static_cast<int>(msg.type));
+  log(LOG_DEBUG, log_msg.append(hex_format(&msg, msg.size())));
   return fuji_message(sockfd, msg.id, &msg, msg.size());
 }
 
 template <size_t N>
 void fuji_send(native_socket sockfd, static_message<N> const& msg) {
-  printf("send: ");
-  print_message(msg);
+  std::string log_msg = string_format("send: %s(%d) ", to_string(msg.type), static_cast<int>(msg.type));
+  log(LOG_DEBUG, log_msg.append(hex_format(&msg, msg.size())));
   fuji_send(sockfd, &msg, msg.size());
 }
 
@@ -100,9 +92,9 @@ bool fuji_twopart_message(native_socket const sockfd, static_message<N1> const& 
 template <size_t N>
 size_t fuji_receive_log(native_socket sockfd, uint8_t(&data)[N]) {
   size_t size = fuji_receive(sockfd, data, N);
-  printf("receive %zu bytes [", size);
-  print_hex(data, size, skip_newline);
-  printf("]\n");
+
+  std::string log_msg = string_format("receive %zu bytes ", size);
+  log(LOG_DEBUG, log_msg.append(hex_format(data, size)));
   return size;
 }
 

--- a/lib/include/settings.hpp
+++ b/lib/include/settings.hpp
@@ -67,6 +67,17 @@ struct shutter_speed {
 };
 char const* to_string(shutter_speed speed);
 
+enum shutter_type {
+  mechanical_shutter,
+  electronic_shutter
+};
+char const* to_string(shutter_type shutter);
+
+struct shutter_settings {
+  shutter_speed speed { 0 };
+  shutter_type type;
+};
+
 enum focus_mode {
   manual_focus = 1,
   single_autofocus = 32769,
@@ -120,12 +131,6 @@ enum white_balance_mode {
 char const* to_string(white_balance_mode white_balance);
 bool parse_white_balance_mode(uint16_t const value, white_balance_mode& mode);
 
-enum shutter_type {
-  mechanical_shutter,
-  electronic_shutter
-};
-char const* to_string(shutter_type shutter);
-
 enum recording_mode {
   movie_button_unavailable = 0,
   movie_button_available = 1
@@ -172,7 +177,6 @@ char const* to_string(flash_mode flash);
 struct camera_settings {
   uint32_t iso;
   uint32_t movie_iso;
-  uint32_t shutter_speed;
   uint32_t device_error;
   uint32_t movie_hd_remaining_time;
   int32_t exposure_compensation;
@@ -181,7 +185,7 @@ struct camera_settings {
   auto_focus_point focus_point;
   image_settings image;
   aperture_f_number aperture;
-  shutter_type shutter;
+  shutter_settings shutter;
   battery_level battery;
   flash_mode flash;
   timer_mode self_timer;
@@ -190,20 +194,9 @@ struct camera_settings {
   shooting_mode shooting;
 };
 
-inline uint64_t shutter_speed_microseconds(camera_settings const& settings) {
-  double msec = 0;
-  auto const spd = settings.shutter_speed;
-
-  if (spd & shutter_flag_subsecond) 
-    msec = 1000.0 * (1000000.0 / settings.shutter_speed);
-  else
-    msec = 1000.0 * settings.shutter_speed;
-
-  return msec;
-}
-
 void print(camera_settings const& settings);
 
+double ss_to_microsec(uint32_t raw_speed);
 }  // namespace fcwt
 
 #endif  // FUJI_CAM_WIFI_TOOL_SETTINGS_HPP

--- a/lib/include/settings.hpp
+++ b/lib/include/settings.hpp
@@ -49,10 +49,26 @@ struct auto_focus_point {
 
 std::string to_string(auto_focus_point const& focus_point);
 
+enum focus_mode {
+  manual_focus = 1,
+  single_autofocus = 32769,
+  continuous_autofocus = 32770
+};
+char const* to_string(focus_mode mode);
+
+enum timer_mode {
+  timer_off = 0,
+  timer_1sec = 1,
+  timer_2sec = 2,
+  timer_5sec = 3,
+  timer_10sec = 4,
+};
+char const* to_string(timer_mode mode);
+
 enum film_simulation_mode {
-  film_simulation_standard = 1,
-  film_simulation_vivid = 2,
-  film_simulation_soft = 3,
+  film_simulation_provia = 1,
+  film_simulation_velvia = 2,
+  film_simulation_astia = 3,
   film_simulation_monochrome = 4,
   film_simulation_sepia = 5,
   film_simulation_pro_neg_hi = 6,
@@ -61,6 +77,12 @@ enum film_simulation_mode {
   film_simulation_monochrome_r_filter = 9,
   film_simulation_monochrome_g_filter = 10,
   film_simulation_classic_chrome = 11,
+  film_simulation_acros = 12,
+  film_simulation_acros_y = 13,
+  film_simulation_acros_r = 14,
+  film_simulation_acros_g = 15,
+  film_simulation_eterna = 16,
+
   film_simulation_count
 };
 
@@ -88,18 +110,70 @@ enum shutter_type {
 };
 char const* to_string(shutter_type shutter);
 
+enum recording_mode {
+  movie_button_unavailable = 0,
+  movie_button_available = 1
+};
+char const* to_string(recording_mode mode);
+
+enum shooting_mode {
+  manual_mode = 1,
+  program_mode = 2,
+  aperture_priority_mode = 3,
+  shutter_priority_mode = 4,
+  auto_mode = 6
+};
+char const* to_string(recording_mode mode);
+
+enum battery_level {
+  critical_battery = 1,
+  one_bar_battery = 2,
+  two_bar_battery = 3,
+  full_battery = 4
+};
+char const* to_string(battery_level level);
+
+enum flash_mode {
+  flash_auto = 1,
+  flash_off = 2,
+  flash_fill_flash = 3,
+  flash_redeye_auto = 4,
+  flash_redeye_fill = 5,
+  flash_external_sync = 6,
+  flash_on = 32769,
+  flash_redeye = 32770,
+  flash_redeye_on = 32771,
+  flash_redeye_sync = 32772,
+  flash_redeye_rear = 32773,
+  flash_slow_sync = 32774,
+  flash_rear_sync = 32775,
+  flash_commander = 32776,
+  flash_disable = 32777,
+  flash_enable = 32778 
+};
+
+char const* to_string(flash_mode flash);
+
 struct camera_settings {
   uint32_t iso;
+  uint32_t movie_iso;
   bool one_div_shutter_speed;
   uint32_t shutter_speed;
+  uint32_t device_error;
+  uint32_t movie_hd_remaining_time;
+  int32_t exposure_compensation;
   white_balance_mode white_balance;
   film_simulation_mode film_simulation;
   auto_focus_point focus_point;
   image_settings image;
   aperture_f_number aperture;
-  int32_t exposure;
   shutter_type shutter;
-  int32_t battery_level;
+  battery_level battery;
+  flash_mode flash;
+  timer_mode self_timer;
+  focus_mode focus;
+  recording_mode recording;
+  shooting_mode shooting;
 };
 
 inline uint64_t shutter_speed_microseconds(camera_settings const& settings) {

--- a/lib/include/settings.hpp
+++ b/lib/include/settings.hpp
@@ -239,7 +239,12 @@ struct shutter_speed {
 };
 char const* to_string(shutter_speed speed);
 
-void print(std::map<property_codes, uint32_t> const& settings);
+struct current_properties {
+  std::vector<property_codes> camera_order;
+  std::map<property_codes, uint32_t> values;
+};
+
+void print(current_properties& settings);
 
 double ss_to_microsec(uint32_t raw_speed);
 }  // namespace fcwt

--- a/lib/include/settings.hpp
+++ b/lib/include/settings.hpp
@@ -99,9 +99,7 @@ enum film_simulation_mode {
   film_simulation_acros_y = 13,
   film_simulation_acros_r = 14,
   film_simulation_acros_g = 15,
-  film_simulation_eterna = 16,
-
-  film_simulation_count
+  film_simulation_eterna = 16
 };
 
 char const* to_string(film_simulation_mode film_simulation);
@@ -154,7 +152,7 @@ char const* to_string(battery_level level);
 enum flash_mode {
   flash_auto = 1,
   flash_off = 2,
-  flash_fill_flash = 3,
+  flash_fill = 3,
   flash_redeye_auto = 4,
   flash_redeye_fill = 5,
   flash_external_sync = 6,
@@ -169,7 +167,6 @@ enum flash_mode {
   flash_disable = 32777,
   flash_enable = 32778 
 };
-
 char const* to_string(flash_mode flash);
 
 struct camera_settings {

--- a/lib/include/settings.hpp
+++ b/lib/include/settings.hpp
@@ -172,7 +172,6 @@ char const* to_string(flash_mode flash);
 struct camera_settings {
   uint32_t iso;
   uint32_t movie_iso;
-  bool one_div_shutter_speed;
   uint32_t shutter_speed;
   uint32_t device_error;
   uint32_t movie_hd_remaining_time;
@@ -192,8 +191,15 @@ struct camera_settings {
 };
 
 inline uint64_t shutter_speed_microseconds(camera_settings const& settings) {
-  double msec = settings.one_div_shutter_speed ? 1000000.0 / settings.shutter_speed : settings.shutter_speed;
-  return msec * 1000.0;
+  double msec = 0;
+  auto const spd = settings.shutter_speed;
+
+  if (spd & shutter_flag_subsecond) 
+    msec = 1000.0 * (1000000.0 / settings.shutter_speed);
+  else
+    msec = 1000.0 * settings.shutter_speed;
+
+  return msec;
 }
 
 void print(camera_settings const& settings);

--- a/lib/include/settings.hpp
+++ b/lib/include/settings.hpp
@@ -206,6 +206,9 @@ static std::map<property_codes, std::map<uint16_t, const char *>> property_value
         { BATTERY_TWO_BAR, "Two bars" },
         { BATTERY_FULL, "Full" },
    }},
+   { property_unknown, {
+        { 0, "== Unknown value! ==" },
+   }},
 };
 
 struct auto_focus_point {

--- a/lib/include/settings.hpp
+++ b/lib/include/settings.hpp
@@ -178,6 +178,7 @@ struct camera_settings {
   uint32_t iso;
   uint32_t movie_iso;
   uint32_t device_error;
+  uint32_t focus_lock;
   uint32_t movie_hd_remaining_time;
   int32_t exposure_compensation;
   white_balance_mode white_balance;

--- a/lib/include/settings.hpp
+++ b/lib/include/settings.hpp
@@ -8,6 +8,12 @@
 
 namespace fcwt {
 
+const uint32_t iso_flag_auto = 1 << 31;
+const uint32_t iso_flag_emulated = 1 << 30;
+const uint32_t iso_value_mask = 0x00ffffff;
+const uint32_t shutter_flag_subsecond = 1 << 31;
+const uint32_t shutter_value_mask = 0x0fffffff;
+
 enum image_format {
   image_format_jpeg,
   image_format_raw_and_jpeg
@@ -39,15 +45,27 @@ struct image_settings {
   jpeg_aspect aspect;
   uint32_t space_on_sdcard;
 };
-
 std::string to_string(image_settings const& image);
 
 struct auto_focus_point {
   uint8_t x;
   uint8_t y;
 };
-
 std::string to_string(auto_focus_point const& focus_point);
+
+struct iso_level {
+  iso_level(uint32_t val) : value(val) {}
+  operator uint32_t() const { return value; }
+  uint32_t value;
+};
+std::string to_string(iso_level iso);
+
+struct shutter_speed {
+  shutter_speed(uint32_t val) : value(val) {}
+  operator uint32_t() const { return value; }
+  uint32_t value;
+};
+char const* to_string(shutter_speed speed);
 
 enum focus_mode {
   manual_focus = 1,

--- a/lib/src/capabilities.cpp
+++ b/lib/src/capabilities.cpp
@@ -6,14 +6,6 @@
 
 namespace fcwt {
 
-std::string to_string(aperture_f_number aperture)
-{
-    if (aperture.value)
-        return string_format("%.1ff", static_cast<float>(aperture.value) / 100.f);
-    else
-        return "auto";
-}
-
 #define PRINT_CAPABILITY(value, value_string, default_value, current_value) \
             std::string flag = ""; \
             if (value == current_value && value == default_value) \
@@ -28,6 +20,11 @@ void print(std::vector<capability> const& caps) {
     printf("camera capabilities:\n");
 
     for (capability cap : caps) {
+        if (! property_strings.count(cap.property_code)) {
+            printf("\t%s: %s\n", property_strings[property_unknown], hex_format(&cap.property_code, 2).c_str());
+            continue;
+        }
+
         printf("\t%s%s:\n", property_strings[cap.property_code], cap.get_set ? "" : " (immutable)");
 /*
         if (cap.form_flag == 1) {
@@ -57,38 +54,13 @@ void print(std::vector<capability> const& caps) {
                                  cap.default_value, cap.current_value);
             }
 
-        } else if (cap.property_code == property_self_timer) {
+        } else if (cap.property_code == property_self_timer ||
+                   cap.property_code == property_flash ||
+                   cap.property_code == property_film_simulation ||
+                   cap.property_code == property_recmode_enable ||
+                   cap.property_code == property_white_balance) {
             for (uint16_t i = 0; i < cap.count; ++i) {
-                timer_mode mode = static_cast<timer_mode>(cap.values[i]);
-                PRINT_CAPABILITY(cap.values[i], to_string(mode),
-                                 cap.default_value, cap.current_value);
-            }
-
-        } else if (cap.property_code == property_flash) {
-            for (uint16_t i = 0; i < cap.count; ++i) {
-                flash_mode mode = static_cast<flash_mode>(cap.values[i]);
-                PRINT_CAPABILITY(cap.values[i], to_string(mode),
-                                 cap.default_value, cap.current_value);
-            }
-
-        } else if (cap.property_code == property_white_balance) {
-            for (uint16_t i = 0; i < cap.count; ++i) {
-                white_balance_mode mode = static_cast<white_balance_mode>(cap.values[i]);
-                PRINT_CAPABILITY(cap.values[i], to_string(mode),
-                                 cap.default_value, cap.current_value);
-            }
-
-        } else if (cap.property_code == property_film_simulation) {
-            for (uint16_t i = 0; i < cap.count; ++i) {
-                film_simulation_mode mode = static_cast<film_simulation_mode>(cap.values[i]);
-                PRINT_CAPABILITY(cap.values[i], to_string(mode),
-                                 cap.default_value, cap.current_value);
-            }
-
-        } else if (cap.property_code == property_recmode_enable) {
-            for (uint16_t i = 0; i < cap.count; ++i) {
-                recording_mode mode = static_cast<recording_mode>(cap.values[i]);
-                PRINT_CAPABILITY(cap.values[i], to_string(mode),
+                PRINT_CAPABILITY(cap.values[i], property_value_strings[cap.property_code][cap.values[i]],
                                  cap.default_value, cap.current_value);
             }
 
@@ -103,8 +75,6 @@ void print(std::vector<capability> const& caps) {
             printf("\t\tvalue: %s\n", to_string(spd));
 
         } else if (cap.property_code == property_focus_point) {
-
-        } else if (cap.property_code == property_unknown) {
 
         }
     }

--- a/lib/src/capabilities.cpp
+++ b/lib/src/capabilities.cpp
@@ -61,10 +61,14 @@ void print(std::vector<capability> const& caps) {
                    cap.property_code == property_white_balance) {
             for (uint16_t i = 0; i < cap.count; ++i) {
                 if (property_value_strings[cap.property_code].count(cap.values[i])) {
-                    PRINT_CAPABILITY(cap.values[i], property_value_strings[cap.property_code][cap.values[i]],
+                    std::string value_str = property_value_strings[cap.property_code][cap.values[i]];
+                    value_str.append(string_format(" (%d)", cap.values[i]));
+                    PRINT_CAPABILITY(cap.values[i], value_str.c_str(),
                                      cap.default_value, cap.current_value);
                 } else {
-                    PRINT_CAPABILITY(cap.values[i], property_value_strings[property_unknown][0],
+                    std::string value_str = property_value_strings[property_unknown][0];
+                    value_str.append(string_format(" (%d)", cap.values[i]));
+                    PRINT_CAPABILITY(cap.values[i], value_str.c_str(),
                                      cap.default_value, cap.current_value);
                 }
             }

--- a/lib/src/capabilities.cpp
+++ b/lib/src/capabilities.cpp
@@ -49,8 +49,8 @@ void print(std::vector<capability> const& caps) {
         } else if (cap.property_code == property_aperture) {
             for (uint16_t i = 0; i < cap.count; ++i) {
                 uint16_t raw_mode = cap.values[i];
-                std::string mode = string_format("%.1ff", static_cast<double>(raw_mode) / 100.0);
-                PRINT_CAPABILITY(raw_mode, mode.c_str(),
+                f_number aperture = raw_mode;
+                PRINT_CAPABILITY(raw_mode, to_string(aperture).c_str(),
                                  cap.default_value, cap.current_value);
             }
 

--- a/lib/src/capabilities.cpp
+++ b/lib/src/capabilities.cpp
@@ -60,8 +60,13 @@ void print(std::vector<capability> const& caps) {
                    cap.property_code == property_recmode_enable ||
                    cap.property_code == property_white_balance) {
             for (uint16_t i = 0; i < cap.count; ++i) {
-                PRINT_CAPABILITY(cap.values[i], property_value_strings[cap.property_code][cap.values[i]],
-                                 cap.default_value, cap.current_value);
+                if (property_value_strings[cap.property_code].count(cap.values[i])) {
+                    PRINT_CAPABILITY(cap.values[i], property_value_strings[cap.property_code][cap.values[i]],
+                                     cap.default_value, cap.current_value);
+                } else {
+                    PRINT_CAPABILITY(cap.values[i], property_value_strings[property_unknown][0],
+                                     cap.default_value, cap.current_value);
+                }
             }
 
         } else if (cap.property_code == property_iso) {

--- a/lib/src/capabilities.cpp
+++ b/lib/src/capabilities.cpp
@@ -14,98 +14,100 @@ std::string to_string(aperture_f_number aperture)
         return "auto";
 }
 
-#define PRINT_CAPABILITY(raw_mode, mode, min_value, value) \
+#define PRINT_CAPABILITY(value, value_string, default_value, current_value) \
             std::string flag = ""; \
-            if (raw_mode == value && value == min_value) \
-                flag = "(minimum/current)"; \
-            else if (raw_mode == min_value) \
-                flag = "(minimum)"; \
-            else if (raw_mode == value) \
+            if (value == current_value && value == default_value) \
+                flag = "(default/current)"; \
+            else if (value == default_value) \
+                flag = "(default)"; \
+            else if (value == current_value) \
                 flag = "(current)"; \
-            printf("\t\t%s %s\n", mode, flag.c_str())
+            printf("\t\t%s %s\n", value_string, flag.c_str())
 
-void print(camera_capabilities const& caps)
-{
+void print(std::vector<capability> const& caps) {
     printf("camera capabilities:\n");
 
-    printf("\tiso levels (%d):\n", caps.iso.count);
-    for (uint32_t i = 0; i < caps.iso.count; ++i)
-    {
-        iso_level const lvl { caps.iso.modes[i] };
-        printf("\t\t%s\n", to_string(lvl).c_str());
+    for (capability cap : caps) {
+        printf("\t%s%s:\n", property_strings[cap.property_code], cap.get_set ? "" : " (immutable)");
+/*
+        if (cap.form_flag == 1) {
+            printf("\t\t    min: %d\n", cap.min_value);
+            printf("\t\t    max: %d\n", cap.max_value);
+            printf("\t\t    step: %d\n", cap.step_size);
+        } else if (cap.form_flag == 2) {
+            for (uint16_t i = 0; i < cap.count; ++i) {
+                printf("\t\t%d\n", cap.values[i]);
+            }
+        }
+*/
+        if (cap.property_code == property_exposure_compensation) {
+            for (uint16_t i = 0; i < cap.count; ++i) {
+                int16_t raw_mode = static_cast<int16_t>(cap.values[i]);
+                std::string mode = string_format("%.1f", static_cast<double>(raw_mode) / 1000.0);
+                PRINT_CAPABILITY(raw_mode, mode.c_str(),
+                                 static_cast<int16_t>(cap.default_value),
+                                 static_cast<int16_t>(cap.current_value));
+            }
+
+        } else if (cap.property_code == property_aperture) {
+            for (uint16_t i = 0; i < cap.count; ++i) {
+                uint16_t raw_mode = cap.values[i];
+                std::string mode = string_format("%.1ff", static_cast<double>(raw_mode) / 100.0);
+                PRINT_CAPABILITY(raw_mode, mode.c_str(),
+                                 cap.default_value, cap.current_value);
+            }
+
+        } else if (cap.property_code == property_self_timer) {
+            for (uint16_t i = 0; i < cap.count; ++i) {
+                timer_mode mode = static_cast<timer_mode>(cap.values[i]);
+                PRINT_CAPABILITY(cap.values[i], to_string(mode),
+                                 cap.default_value, cap.current_value);
+            }
+
+        } else if (cap.property_code == property_flash) {
+            for (uint16_t i = 0; i < cap.count; ++i) {
+                flash_mode mode = static_cast<flash_mode>(cap.values[i]);
+                PRINT_CAPABILITY(cap.values[i], to_string(mode),
+                                 cap.default_value, cap.current_value);
+            }
+
+        } else if (cap.property_code == property_white_balance) {
+            for (uint16_t i = 0; i < cap.count; ++i) {
+                white_balance_mode mode = static_cast<white_balance_mode>(cap.values[i]);
+                PRINT_CAPABILITY(cap.values[i], to_string(mode),
+                                 cap.default_value, cap.current_value);
+            }
+
+        } else if (cap.property_code == property_film_simulation) {
+            for (uint16_t i = 0; i < cap.count; ++i) {
+                film_simulation_mode mode = static_cast<film_simulation_mode>(cap.values[i]);
+                PRINT_CAPABILITY(cap.values[i], to_string(mode),
+                                 cap.default_value, cap.current_value);
+            }
+
+        } else if (cap.property_code == property_recmode_enable) {
+            for (uint16_t i = 0; i < cap.count; ++i) {
+                recording_mode mode = static_cast<recording_mode>(cap.values[i]);
+                PRINT_CAPABILITY(cap.values[i], to_string(mode),
+                                 cap.default_value, cap.current_value);
+            }
+
+        } else if (cap.property_code == property_iso) {
+            for (uint32_t i = 0; i < cap.count; ++i) {
+                iso_level const lvl { cap.values[i] };
+                printf("\t\t%s\n", to_string(lvl).c_str());
+            }
+
+        } else if (cap.property_code == property_shutter_speed) {
+            shutter_speed const spd { cap.current_value };
+            printf("\t\tvalue: %s\n", to_string(spd));
+
+        } else if (cap.property_code == property_focus_point) {
+
+        } else if (cap.property_code == property_unknown) {
+
+        }
     }
-
-    printf("\tshutter speed:\n");
-    shutter_speed const spd { caps.shutter.value };
-    printf("\t\tvalue: %s\n", to_string(spd));
-
-    printf("\taperture modes:\n");
-    for (uint16_t i = 0; i < caps.aperture.count; ++i) {
-        uint16_t raw_mode = caps.aperture.modes[i];
-        double mode = static_cast<double>(raw_mode) / 100.0;
-
-        if (raw_mode == caps.aperture.value &&
-              raw_mode == caps.aperture.min_value)
-            printf("\t\t%.1ff (minimum/current)\n", mode);
-        else if (raw_mode == caps.aperture.min_value)
-            printf("\t\t%.1ff (minimum)\n", mode);
-        else if (raw_mode == caps.aperture.value)
-            printf("\t\t%.1ff (current)\n", mode);
-        else
-            printf("\t\t%.1ff\n", mode);
-    }
-
-    printf("\tflash modes (%d):\n", caps.flash.count);
-    for (uint16_t i = 0; i < caps.flash.count; ++i) {
-        flash_mode mode = static_cast<flash_mode>(caps.flash.modes[i]);
-        PRINT_CAPABILITY(caps.flash.modes[i], to_string(mode),
-                         caps.flash.min_value, caps.flash.value);
-    }
-
-    printf("\twhite balance modes (%d):\n", caps.white_balance.count);
-    for (uint16_t i = 0; i < caps.white_balance.count; ++i) {
-        white_balance_mode mode = static_cast<white_balance_mode>(caps.white_balance.modes[i]);
-        PRINT_CAPABILITY(caps.white_balance.modes[i], to_string(mode),
-                         caps.white_balance.min_value, caps.white_balance.value);
-    }
-
-    printf("\tfilm simulation modes (%d):\n", caps.film_simulation.count);
-    for (uint16_t i = 0; i < caps.film_simulation.count; ++i) {
-        film_simulation_mode mode = static_cast<film_simulation_mode>(caps.film_simulation.modes[i]);
-        PRINT_CAPABILITY(caps.film_simulation.modes[i], to_string(mode),
-                         caps.film_simulation.min_value, caps.film_simulation.value);
-    }
-
-    printf("\trecording modes (%d):\n", caps.recording.count);
-    for (uint16_t i = 0; i < caps.recording.count; ++i) {
-        recording_mode mode = static_cast<recording_mode>(caps.recording.modes[i]);
-        PRINT_CAPABILITY(caps.recording.modes[i], to_string(mode),
-                         caps.recording.min_value, caps.recording.value);
-    }
-
-    printf("\tself timer modes (%d):\n", caps.self_timer.count);
-    for (uint16_t i = 0; i < caps.self_timer.count; ++i) {
-        timer_mode mode = static_cast<timer_mode>(caps.self_timer.modes[i]);
-        PRINT_CAPABILITY(caps.self_timer.modes[i], to_string(mode),
-                         caps.self_timer.min_value, caps.self_timer.value);
-    }
-
-    printf("\texposure compensation modes (%d):\n", caps.exposure_compensation.count);
-    for (uint16_t i = 0; i < caps.exposure_compensation.count; ++i) {
-        int16_t raw_mode = static_cast<int16_t>(caps.exposure_compensation.modes[i]);
-        double mode = static_cast<double>(raw_mode) / 1000.0;
-
-        if (caps.exposure_compensation.modes[i] == caps.exposure_compensation.value &&
-                 caps.exposure_compensation.modes[i] == caps.exposure_compensation.min_value)
-            printf("\t\t%.1f (%d) (minimum/current)\n", mode, raw_mode);
-        else if (caps.exposure_compensation.modes[i] == caps.exposure_compensation.min_value)
-            printf("\t\t%.1f (%d) (minimum)\n", mode, raw_mode);
-        else if (caps.exposure_compensation.modes[i] == caps.exposure_compensation.value)
-            printf("\t\t%.1f (%d) (current)\n", mode, raw_mode);
-        else
-            printf("\t\t%.1f (%d)\n", mode, raw_mode);
-    }
-
 }
 
 } // namespace fcwt

--- a/lib/src/capabilities.cpp
+++ b/lib/src/capabilities.cpp
@@ -6,23 +6,6 @@
 
 namespace fcwt {
 
-std::string to_string(iso_level iso)
-{
-    auto const lvl = iso.value;
-    char const* flag = "";
-
-    // movie iso auto is  0xffffffff
-    if (lvl == 0xffffffff)
-        return "auto";
-
-    if (lvl & iso_flag_auto) 
-        flag = " (auto)";
-    else if (lvl & iso_flag_emulated)
-        flag = " (emulated)";
-
-    return string_format("%12d%s", lvl & iso_value_mask, flag);
-}
-
 std::string to_string(aperture_f_number aperture)
 {
     if (aperture.value)
@@ -53,12 +36,8 @@ void print(camera_capabilities const& caps)
     }
 
     printf("\tshutter speed:\n");
-    bool sub_second = caps.shutter.value & shutter_flag_subsecond;
-    double value = static_cast<double>(caps.shutter.value & shutter_value_mask) / 1000.0;
-    if (sub_second)
-        printf("\t\t1/%.1fs\n", value);
-    else
-        printf("\t\t%.1fs\n", value);
+    shutter_speed const spd { caps.shutter.value };
+    printf("\t\tvalue: %s\n", to_string(spd));
 
     printf("\taperture modes:\n");
     for (uint16_t i = 0; i < caps.aperture.count; ++i) {

--- a/lib/src/capabilities.cpp
+++ b/lib/src/capabilities.cpp
@@ -1,7 +1,8 @@
 #include "capabilities.hpp"
+#include "settings.hpp"
+#include "log.hpp"
 
 #include <stdio.h>
-#include "log.hpp"
 
 namespace fcwt {
 
@@ -9,6 +10,11 @@ std::string to_string(iso_level iso)
 {
     auto const lvl = iso.value;
     char const* flag = "";
+
+    // movie iso auto is  0xffffffff
+    if (lvl == 0xffffffff)
+        return "auto";
+
     if (lvl & iso_flag_auto) 
         flag = " (auto)";
     else if (lvl & iso_flag_emulated)
@@ -20,30 +26,107 @@ std::string to_string(iso_level iso)
 std::string to_string(aperture_f_number aperture)
 {
     if (aperture.value)
-        return string_format("%.1f", static_cast<float>(aperture.value) / 100.f);
+        return string_format("%.1ff", static_cast<float>(aperture.value) / 100.f);
     else
         return "auto";
 }
+
+#define PRINT_CAPABILITY(raw_mode, mode, min_value, value) \
+            std::string flag = ""; \
+            if (raw_mode == value && value == min_value) \
+                flag = "(minimum/current)"; \
+            else if (raw_mode == min_value) \
+                flag = "(minimum)"; \
+            else if (raw_mode == value) \
+                flag = "(current)"; \
+            printf("\t\t%s %s\n", mode, flag.c_str())
 
 void print(camera_capabilities const& caps)
 {
     printf("camera capabilities:\n");
 
-    printf("\tiso levels (%d):\n", caps.iso.numLevels);
-    for (uint32_t i = 0; i < caps.iso.numLevels; ++i)
+    printf("\tiso levels (%d):\n", caps.iso.count);
+    for (uint32_t i = 0; i < caps.iso.count; ++i)
     {
-        iso_level const lvl { caps.iso.levels[i] };
+        iso_level const lvl { caps.iso.modes[i] };
         printf("\t\t%s\n", to_string(lvl).c_str());
     }
 
     printf("\tshutter speed:\n");
-    printf("\t\tmode: %s\n", caps.shutter_speed.mode == shutter_speed_auto ? "auto" : "manual");
-    if (caps.shutter_speed.mode == shutter_speed_manual)
-        printf("\t\ttime: 1/%ds\n", caps.shutter_speed.value);
+    bool sub_second = caps.shutter.value & shutter_flag_subsecond;
+    double value = static_cast<double>(caps.shutter.value & shutter_value_mask) / 1000.0;
+    if (sub_second)
+        printf("\t\t1/%.1fs\n", value);
     else
-        printf("\t\texposure compensation: %d\n", static_cast<int>(caps.shutter_speed.exposure));
-    printf("\taperture:\n");
-    printf("\t\tvalue: %s\n", to_string(caps.aperture).c_str());
+        printf("\t\t%.1fs\n", value);
+
+    printf("\taperture modes:\n");
+    for (uint16_t i = 0; i < caps.aperture.count; ++i) {
+        uint16_t raw_mode = caps.aperture.modes[i];
+        double mode = static_cast<double>(raw_mode) / 100.0;
+
+        if (raw_mode == caps.aperture.value &&
+              raw_mode == caps.aperture.min_value)
+            printf("\t\t%.1ff (minimum/current)\n", mode);
+        else if (raw_mode == caps.aperture.min_value)
+            printf("\t\t%.1ff (minimum)\n", mode);
+        else if (raw_mode == caps.aperture.value)
+            printf("\t\t%.1ff (current)\n", mode);
+        else
+            printf("\t\t%.1ff\n", mode);
+    }
+
+    printf("\tflash modes (%d):\n", caps.flash.count);
+    for (uint16_t i = 0; i < caps.flash.count; ++i) {
+        flash_mode mode = static_cast<flash_mode>(caps.flash.modes[i]);
+        PRINT_CAPABILITY(caps.flash.modes[i], to_string(mode),
+                         caps.flash.min_value, caps.flash.value);
+    }
+
+    printf("\twhite balance modes (%d):\n", caps.white_balance.count);
+    for (uint16_t i = 0; i < caps.white_balance.count; ++i) {
+        white_balance_mode mode = static_cast<white_balance_mode>(caps.white_balance.modes[i]);
+        PRINT_CAPABILITY(caps.white_balance.modes[i], to_string(mode),
+                         caps.white_balance.min_value, caps.white_balance.value);
+    }
+
+    printf("\tfilm simulation modes (%d):\n", caps.film_simulation.count);
+    for (uint16_t i = 0; i < caps.film_simulation.count; ++i) {
+        film_simulation_mode mode = static_cast<film_simulation_mode>(caps.film_simulation.modes[i]);
+        PRINT_CAPABILITY(caps.film_simulation.modes[i], to_string(mode),
+                         caps.film_simulation.min_value, caps.film_simulation.value);
+    }
+
+    printf("\trecording modes (%d):\n", caps.recording.count);
+    for (uint16_t i = 0; i < caps.recording.count; ++i) {
+        recording_mode mode = static_cast<recording_mode>(caps.recording.modes[i]);
+        PRINT_CAPABILITY(caps.recording.modes[i], to_string(mode),
+                         caps.recording.min_value, caps.recording.value);
+    }
+
+    printf("\tself timer modes (%d):\n", caps.self_timer.count);
+    for (uint16_t i = 0; i < caps.self_timer.count; ++i) {
+        timer_mode mode = static_cast<timer_mode>(caps.self_timer.modes[i]);
+        PRINT_CAPABILITY(caps.self_timer.modes[i], to_string(mode),
+                         caps.self_timer.min_value, caps.self_timer.value);
+    }
+
+    printf("\texposure compensation modes (%d):\n", caps.exposure_compensation.count);
+    for (uint16_t i = 0; i < caps.exposure_compensation.count; ++i) {
+        int16_t raw_mode = static_cast<int16_t>(caps.exposure_compensation.modes[i]);
+        double mode = static_cast<double>(raw_mode) / 1000.0;
+
+        if (caps.exposure_compensation.modes[i] == caps.exposure_compensation.value &&
+                 caps.exposure_compensation.modes[i] == caps.exposure_compensation.min_value)
+            printf("\t\t%.1f (%d) (minimum/current)\n", mode, raw_mode);
+        else if (caps.exposure_compensation.modes[i] == caps.exposure_compensation.min_value)
+            printf("\t\t%.1f (%d) (minimum)\n", mode, raw_mode);
+        else if (caps.exposure_compensation.modes[i] == caps.exposure_compensation.value)
+            printf("\t\t%.1f (%d) (current)\n", mode, raw_mode);
+        else
+            printf("\t\t%.1f (%d)\n", mode, raw_mode);
+    }
+
 }
 
 } // namespace fcwt

--- a/lib/src/comm.cpp
+++ b/lib/src/comm.cpp
@@ -163,14 +163,14 @@ sock connect_to_camera(int port) {
     getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (char*)&so_error, &len);
 
     if (so_error == 0) {
-      printf("Connection esatablished %s:%d (%lld)\n", server_ipv4_addr, port,
-             (long long) sockfd);
+      log(LOG_INFO, string_format("Connection esatablished %s:%d (%lld)",
+                                  server_ipv4_addr, port, (long long) sockfd));
       set_nonblocking_io(sockfd, false);
       return sockfd;
     }
   }
 
-  printf("Failed to connect\n");
+  log(LOG_ERROR, "Failed to connect");
   close_socket(sockfd);
   
   return 0;
@@ -230,7 +230,7 @@ size_t fuji_receive(native_socket sockfd, void* data, size_t sizeBytes) {
   receive_data(sockfd, &size, sizeof(size));
   size = from_fuji_size_prefix(size);
   if (size < sizeof(size)) {
-    LOG_WARN("fuji_receive, 0x invalid message");
+    log(LOG_WARN, "fuji_receive, 0x invalid message");
     return 0;
   }
   size -= sizeof(size);

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -426,7 +426,7 @@ bool shutter(native_socket const sockfd, native_socket const sockfd2, const char
   return success;
 }
 
-bool current_settings(native_socket sockfd, std::map<property_codes, uint32_t>& settings) {
+bool current_settings(native_socket sockfd, current_properties& settings) {
   auto const msg = generate<status_request_message>();
   fuji_send(sockfd, &msg, sizeof(msg));
   uint8_t buf[1024];
@@ -443,6 +443,8 @@ bool current_settings(native_socket sockfd, std::map<property_codes, uint32_t>& 
   memcpy(&numSettings, ptr, 2);
   ptr += 2;
 
+  settings.camera_order.clear();
+
   for (uint16_t i = 0; i < numSettings; ++i) {
     property_codes code;
     uint32_t value;
@@ -450,7 +452,8 @@ bool current_settings(native_socket sockfd, std::map<property_codes, uint32_t>& 
     memcpy(&code, data, 2);
     memcpy(&value, data + 2, 4);
 
-    settings[code] = value;
+    settings.camera_order.push_back(code);
+    settings.values[code] = value;
 
     std::string log_setting = std::string("Setting msg: ").append(hex_format(&code, 2))
                                                           .append(hex_format(&value, 4));

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -670,6 +670,8 @@ bool current_settings(native_socket sockfd, camera_settings& settings) {
       } break;
 
       case 0xD240: {
+        // shutter speed; 4 bytes; MSB is a flag to indicate whether this
+        // is a subsecond value (i.e. 1/Ns)
         log(LOG_DEBUG2, log_setting.append("(SHUTTER_SPEED)"));
         settings.shutter_speed = value;
       } break;

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -251,17 +251,12 @@ void read_capability_submsg(camera_capabilities& caps,
     case 6: {
       switch (header.type) {
         case 0xD02A: {
-          log(LOG_DEBUG, log_capability.append("(ISO)"));
-          const size_t offset = 14;
-          if (size >= offset) {
-            memcpy(&caps.iso.count, data + offset, 2);
-            memcpy(caps.iso.modes, data + offset + 2,
-                   std::min(caps.iso.count, iso_max_modes) * 4);
-          }
+          log(LOG_DEBUG2, log_capability.append("(ISO)"));
+          parse_capability(caps.iso, data, 4);
         } break;
 
         case 0xD240: {
-          log(LOG_DEBUG, log_capability.append("(SHUTTER_SPEED)"));
+          log(LOG_DEBUG2, log_capability.append("(SHUTTER_SPEED)"));
           parse_capability(caps.shutter, data, 4);
         } break;
 
@@ -678,9 +673,7 @@ bool current_settings(native_socket sockfd, camera_settings& settings) {
 
       case 0xD240: {
         log(LOG_DEBUG2, log_setting.append("(SHUTTER_SPEED)"));
-        const uint32_t shutter_speed_value_mask = ~0x80000000;
-        settings.shutter_speed = value & shutter_speed_value_mask;
-        settings.one_div_shutter_speed = settings.shutter_speed != value;
+        settings.shutter_speed = value;
       } break;
 
       case 0xD241: {

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -316,6 +316,7 @@ camera_capabilities parse_camera_caps(void const* data, size_t const size) {
 }  // namespace
 
 bool update_setting(native_socket sockfd, iso_level iso) {
+  if (sockfd <= 0) return false;
   auto const msg_1 =
       make_static_message(message_type::two_part, 0x2A, 0xD0, 0x00, 0x00);
   auto const msg_2 = make_static_message_followup(msg_1, make_byte_array(iso));
@@ -327,6 +328,7 @@ bool update_setting(native_socket sockfd, image_settings image) {
 }
 
 bool update_setting(native_socket sockfd, film_simulation_mode film) {
+  if (sockfd <= 0) return false;
   auto const msg_1 =
     make_static_message(message_type::two_part, 0x01, 0xd0, 0x00, 0x00);
   auto const msg_2 = make_static_message_followup(msg_1, make_byte_array(static_cast<uint16_t>(film)));
@@ -334,6 +336,7 @@ bool update_setting(native_socket sockfd, film_simulation_mode film) {
 }
 
 bool update_setting(native_socket sockfd, flash_mode flash) {
+  if (sockfd <= 0) return false;
   auto const msg_1 =
     make_static_message(message_type::two_part, 0x0c, 0x50, 0x00, 0x00);
   auto const msg_2 = make_static_message_followup(msg_1, make_byte_array(static_cast<uint16_t>(flash)));
@@ -341,6 +344,7 @@ bool update_setting(native_socket sockfd, flash_mode flash) {
 }
 
 bool update_setting(native_socket sockfd, timer_mode timer) {
+  if (sockfd <= 0) return false;
   auto const msg_1 =
     make_static_message(message_type::two_part, 0x12, 0x50, 0x00, 0x00);
   auto const msg_2 = make_static_message_followup(msg_1, make_byte_array(static_cast<uint16_t>(timer)));
@@ -348,15 +352,18 @@ bool update_setting(native_socket sockfd, timer_mode timer) {
 }
 
 bool update_setting(native_socket sockfd, auto_focus_point point) {
+  if (sockfd <= 0) return false;
   auto const msg = make_static_message(message_type::focus_point, point.y, point.x, 0x02, 0x03);
   return fuji_message(sockfd, msg);
 }
 
 bool unlock_focus(native_socket sockfd) {
+  if (sockfd <= 0) return false;
   return fuji_message(sockfd, make_static_message(message_type::focus_unlock));
 }
 
 bool update_setting(native_socket sockfd, white_balance_mode white_balance) {
+  if (sockfd <= 0) return false;
   //10:00:00:00 01:00:16:10 68:00:00:00 05:50:00:00
   //0e:00:00:00 02:00:16:10 68:00:00:00 06:80
   auto const msg_1 =
@@ -366,18 +373,21 @@ bool update_setting(native_socket sockfd, white_balance_mode white_balance) {
 }
 
 bool update_setting(native_socket sockfd, fnumber_update_direction dir) {
+  if (sockfd <= 0) return false;
   auto const msg = make_static_message(
       message_type::aperture, dir == fnumber_increment ? 1 : 0, 0, 0, 0);
   return fuji_message(sockfd, msg);
 }
 
 bool update_setting(native_socket sockfd, ss_update_direction dir) {
+  if (sockfd <= 0) return false;
   auto const msg = make_static_message(
       message_type::shutter_speed, dir == ss_increment ? 1 : 0, 0, 0, 0);
   return fuji_message(sockfd, msg);
 }
 
 bool update_setting(native_socket sockfd, exp_update_direction dir) {
+  if (sockfd <= 0) return false;
   auto const msg = make_static_message(
       message_type::exposure_correction, dir == exp_increment ? 1 : 0, 0, 0, 0);
   return fuji_message(sockfd, msg);
@@ -583,6 +593,9 @@ bool current_settings(native_socket sockfd, camera_settings& settings) {
   fuji_send(sockfd, &msg, sizeof(msg));
   uint8_t buf[1024];
   size_t receivedBytes = fuji_receive(sockfd, buf);
+
+  if (receivedBytes == 0)
+    return false;
 
   log(LOG_DEBUG2, string_format("Status: %zd bytes ", receivedBytes).append(hex_format(buf, receivedBytes)));
 

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -631,7 +631,7 @@ bool current_settings(native_socket sockfd, camera_settings& settings) {
       case 0xD028: {
         // shutter type when shutter is in auto mode, 0 = MS+ES, 1 = ES
         log(LOG_DEBUG2, log_setting.append("(SHUTTER_TYPE)"));
-        settings.shutter = value ? electronic_shutter : mechanical_shutter;
+        settings.shutter.type = value ? electronic_shutter : mechanical_shutter;
       } break;
 
       case 0xD02A: {
@@ -673,7 +673,7 @@ bool current_settings(native_socket sockfd, camera_settings& settings) {
         // shutter speed; 4 bytes; MSB is a flag to indicate whether this
         // is a subsecond value (i.e. 1/Ns)
         log(LOG_DEBUG2, log_setting.append("(SHUTTER_SPEED)"));
-        settings.shutter_speed = value;
+        settings.shutter.speed = value;
       } break;
 
       case 0xD241: {

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -651,7 +651,7 @@ bool current_settings(native_socket sockfd, camera_settings& settings) {
 
       case 0xD209: {
         // focus color (S1_LOCK_COLOR)
-        log(LOG_WARN, log_setting.insert(0, "Known but unused setting"));
+        log(LOG_WARN, log_setting.append("(Known but unused setting)"));
       } break;
 
       case 0xd21b: {

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -404,8 +404,6 @@ bool init_control_connection(native_socket const sockfd, char const* deviceName,
 
   fuji_send(sockfd, make_static_message(message_type::camera_capabilities));
   auto size = fuji_receive_log(sockfd, buffer);
-  print_uint32(buffer, size);
-  print_ascii(buffer, size);
 
   if (caps) *caps = parse_camera_caps(buffer, size);
 

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -348,7 +348,7 @@ bool update_setting(native_socket sockfd, timer_mode timer) {
 }
 
 bool update_setting(native_socket sockfd, auto_focus_point point) {
-  auto const msg = make_static_message(message_type::focus_point, point.x, point.y, 0x02, 0x03);
+  auto const msg = make_static_message(message_type::focus_point, point.y, point.x, 0x02, 0x03);
   return fuji_message(sockfd, msg);
 }
 

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -380,7 +380,6 @@ bool init_control_connection(native_socket const sockfd, char const* deviceName,
     return false;
   }
 
-  auto msg2 = make_static_message(message_type::start, 0x01, 0x00, 0x00, 0x00);
   fuji_message(
       sockfd, make_static_message(message_type::start, 0x01, 0x00, 0x00, 0x00));
 

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -348,7 +348,12 @@ bool update_setting(native_socket sockfd, timer_mode timer) {
 }
 
 bool update_setting(native_socket sockfd, auto_focus_point point) {
-  return false;
+  auto const msg = make_static_message(message_type::focus_point, point.x, point.y, 0x02, 0x03);
+  return fuji_message(sockfd, msg);
+}
+
+bool unlock_focus(native_socket sockfd) {
+  return fuji_message(sockfd, make_static_message(message_type::focus_unlock));
 }
 
 bool update_setting(native_socket sockfd, white_balance_mode white_balance) {

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -677,8 +677,9 @@ bool current_settings(native_socket sockfd, camera_settings& settings) {
       } break;
 
       case 0xD209: {
-        // focus color (S1_LOCK_COLOR)
-        log(LOG_WARN, log_setting.append("(Known but unused setting)"));
+        // focus lock (S1_LOCK_COLOR)
+        log(LOG_DEBUG2, log_setting.append("(FOCUS_LOCK)"));
+        settings.focus_lock = value;
       } break;
 
       case 0xd21b: {

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -327,7 +327,10 @@ bool update_setting(native_socket sockfd, image_settings image) {
 }
 
 bool update_setting(native_socket sockfd, film_simulation_mode film) {
-  return false;
+  auto const msg_1 =
+    make_static_message(message_type::two_part, 0x01, 0xd0, 0x00, 0x00);
+  auto const msg_2 = make_static_message_followup(msg_1, make_byte_array(static_cast<uint16_t>(film)));
+  return fuji_twopart_message(sockfd, msg_1, msg_2);
 }
 
 bool update_setting(native_socket sockfd, auto_focus_point point) {

--- a/lib/src/commands.cpp
+++ b/lib/src/commands.cpp
@@ -333,6 +333,20 @@ bool update_setting(native_socket sockfd, film_simulation_mode film) {
   return fuji_twopart_message(sockfd, msg_1, msg_2);
 }
 
+bool update_setting(native_socket sockfd, flash_mode flash) {
+  auto const msg_1 =
+    make_static_message(message_type::two_part, 0x0c, 0x50, 0x00, 0x00);
+  auto const msg_2 = make_static_message_followup(msg_1, make_byte_array(static_cast<uint16_t>(flash)));
+  return fuji_twopart_message(sockfd, msg_1, msg_2);
+}
+
+bool update_setting(native_socket sockfd, timer_mode timer) {
+  auto const msg_1 =
+    make_static_message(message_type::two_part, 0x12, 0x50, 0x00, 0x00);
+  auto const msg_2 = make_static_message_followup(msg_1, make_byte_array(static_cast<uint16_t>(timer)));
+  return fuji_twopart_message(sockfd, msg_1, msg_2);
+}
+
 bool update_setting(native_socket sockfd, auto_focus_point point) {
   return false;
 }
@@ -346,15 +360,21 @@ bool update_setting(native_socket sockfd, white_balance_mode white_balance) {
   return fuji_twopart_message(sockfd, msg_1, msg_2);
 }
 
-bool update_setting(native_socket sockfd, aperture_f_stop aperture) {
+bool update_setting(native_socket sockfd, fnumber_update_direction dir) {
   auto const msg = make_static_message(
-      message_type::aperture, aperture == aperture_close_third_stop ? 1 : 0, 0, 0, 0);
+      message_type::aperture, dir == fnumber_increment ? 1 : 0, 0, 0, 0);
   return fuji_message(sockfd, msg);
 }
 
-bool update_setting(native_socket sockfd, shutter_speed_stop shutter_speed) {
+bool update_setting(native_socket sockfd, ss_update_direction dir) {
   auto const msg = make_static_message(
-      message_type::shutter_speed, shutter_speed == shutter_speed_one_stop_faster ? 1 : 0, 0, 0, 0);
+      message_type::shutter_speed, dir == ss_increment ? 1 : 0, 0, 0, 0);
+  return fuji_message(sockfd, msg);
+}
+
+bool update_setting(native_socket sockfd, exp_update_direction dir) {
+  auto const msg = make_static_message(
+      message_type::exposure_correction, dir == exp_increment ? 1 : 0, 0, 0, 0);
   return fuji_message(sockfd, msg);
 }
 

--- a/lib/src/log.cpp
+++ b/lib/src/log.cpp
@@ -29,6 +29,10 @@ void log(uint8_t level, std::string msg) {
         printf("[DEBUG] %s\n", msg.c_str());
         break;
       }
+      case LOG_DEBUG2: {
+        printf("[DEBUG2] %s\n", msg.c_str());
+        break;
+      }
     }
 }
 

--- a/lib/src/log.cpp
+++ b/lib/src/log.cpp
@@ -32,20 +32,24 @@ void log(uint8_t level, char const* msg) {
     }
 }
 
-void print_hex(void const* data, size_t const sizeBytes, append_newline anl) {
+std::string hex_format(void const* data, size_t const sizeBytes) {
+  std::string output = "[";
   size_t i = 0;
+
   while (i < sizeBytes) {
-    printf("%02X", static_cast<unsigned char const*>(data)[i]);
+    output.append(string_format("%02X", static_cast<unsigned char const*>(data)[i]));
     ++i;
     if (i == sizeBytes) break;
 
     if (i % 4 == 0)
-      printf(" ");
+      output.append(" ");
     else
-      printf(":");
+      output.append(":");
   }
 
-  if (anl == newline) printf("\n");
+  output.append("]");
+
+  return output;
 }
 
 void print_ascii(void const* data, size_t const sizeBytes, append_newline anl) {
@@ -73,7 +77,7 @@ void print_uint32(void const* data, size_t sizeBytes, append_newline anl) {
   // remaining bytes
   auto const remainingBytes = sizeBytes % 4;
   if (remainingBytes > 0) printf(" ");
-  print_hex(&bytes[numInts * 4], remainingBytes, anl);
+  printf(hex_format(&bytes[numInts * 4], remainingBytes).c_str());
 }
 
 void fatal_error(char const* msg) {

--- a/lib/src/log.cpp
+++ b/lib/src/log.cpp
@@ -8,6 +8,30 @@
 
 namespace fcwt {
 
+log_settings log_s;
+
+void log(uint8_t level, char const* msg) {
+  if (level <= log_s.level)
+    switch(level) {
+      case LOG_ERROR: {
+        printf("[ERROR] %s\n", msg);
+        break;
+      }
+      case LOG_WARN: {
+        printf("[WARN] %s\n", msg);
+        break;
+      }
+      case LOG_INFO: {
+        printf("[INFO] %s\n", msg);
+        break;
+      }
+      case LOG_DEBUG: {
+        printf("[DEBUG] %s\n", msg);
+        break;
+      }
+    }
+}
+
 void print_hex(void const* data, size_t const sizeBytes, append_newline anl) {
   size_t i = 0;
   while (i < sizeBytes) {

--- a/lib/src/log.cpp
+++ b/lib/src/log.cpp
@@ -10,23 +10,23 @@ namespace fcwt {
 
 log_settings log_s;
 
-void log(uint8_t level, char const* msg) {
+void log(uint8_t level, std::string msg) {
   if (level <= log_s.level)
     switch(level) {
       case LOG_ERROR: {
-        printf("[ERROR] %s\n", msg);
+        printf("[ERROR] %s\n", msg.c_str());
         break;
       }
       case LOG_WARN: {
-        printf("[WARN] %s\n", msg);
+        printf("[WARN] %s\n", msg.c_str());
         break;
       }
       case LOG_INFO: {
-        printf("[INFO] %s\n", msg);
+        printf("[INFO] %s\n", msg.c_str());
         break;
       }
       case LOG_DEBUG: {
-        printf("[DEBUG] %s\n", msg);
+        printf("[DEBUG] %s\n", msg.c_str());
         break;
       }
     }

--- a/lib/src/log.cpp
+++ b/lib/src/log.cpp
@@ -8,10 +8,8 @@
 
 namespace fcwt {
 
-log_settings log_s;
-
 void log(uint8_t level, std::string msg) {
-  if (level <= log_s.level)
+  if (level <= log_conf.level)
     switch(level) {
       case LOG_ERROR: {
         printf("[ERROR] %s\n", msg.c_str());

--- a/lib/src/message.cpp
+++ b/lib/src/message.cpp
@@ -35,8 +35,7 @@ bool fuji_message(native_socket const sockfd, uint32_t const id, void const* mes
   size_t receivedBytes = fuji_receive_log(sockfd, buffer);
 
   if (!is_success_response(id, buffer, receivedBytes)) {
-    LOG_INFO_FORMAT("received %zd bytes", receivedBytes);
-    print_hex(buffer, receivedBytes);
+    log(LOG_DEBUG, string_format("received %zd bytes ", receivedBytes).append(hex_format(buffer, receivedBytes)));
     return false;
   }
 
@@ -56,10 +55,8 @@ bool is_success_response(uint32_t const id, void const* buffer,
   success.id = id;
   bool const result = memcmp(&success, buffer, 8) == 0;
   if (!result) {
-    LOG_INFO("expected: ");
-    print_hex(&success, 8);
-    LOG_INFO("actual: ");
-    print_hex(buffer, 8);
+    log(LOG_WARN, std::string("expected: ").append(hex_format(&success, 8)));
+    log(LOG_WARN, std::string("actual: ").append(hex_format(buffer, 8)));
   }
   return result;
 }

--- a/lib/src/message.cpp
+++ b/lib/src/message.cpp
@@ -19,6 +19,10 @@ char const* to_string(message_type type) {
     MESSAGE_TYPE_TO_STRING_CASE(single_part);
     MESSAGE_TYPE_TO_STRING_CASE(two_part);
     MESSAGE_TYPE_TO_STRING_CASE(full_image);
+    MESSAGE_TYPE_TO_STRING_CASE(focus_point);
+    MESSAGE_TYPE_TO_STRING_CASE(shutter_speed);
+    MESSAGE_TYPE_TO_STRING_CASE(aperture);
+    MESSAGE_TYPE_TO_STRING_CASE(exposure_correction);
     MESSAGE_TYPE_TO_STRING_CASE(camera_remote);
     MESSAGE_TYPE_TO_STRING_CASE(camera_last_image);
     MESSAGE_TYPE_TO_STRING_CASE(camera_capabilities);

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -10,6 +10,32 @@ namespace fcwt {
 #define CASE_RETURN_ENUM_TO_STRING(x) case x: return #x;
 #define CASE_ASSIGN_AND_BREAK(r, x) case x: r = x; break
 
+std::string to_string(iso_level iso) {
+    auto const lvl = iso.value;
+    char const* flag = "";
+
+    // movie iso auto is  0xffffffff
+    if (lvl == 0xffffffff)
+        return "auto";
+
+    if (lvl & iso_flag_auto) 
+        flag = "(auto)";
+    else if (lvl & iso_flag_emulated)
+        flag = "(emulated)";
+
+    return string_format("%12d %s", lvl & iso_value_mask, flag);
+}
+
+char const* to_string(shutter_speed speed) {
+    auto const spd = speed.value;
+
+    double out = static_cast<double>(spd & shutter_value_mask) / 1000.0;
+    if (spd & shutter_flag_subsecond) 
+        return string_format("1/%.1fs", out).c_str();
+    else
+        return string_format("%.1fs", out).c_str();
+}
+
 char const* to_string(image_format const format) {
   switch (format) {
     CASE_RETURN_ENUM_TO_STRING(image_format_jpeg);
@@ -204,10 +230,13 @@ std::string to_string(image_settings const& image) {
 }
 
 void print(camera_settings const& settings) {
+  iso_level iso = { settings.iso };
+  iso_level movie_iso = { settings.movie_iso };
+  shutter_speed speed = { settings.shutter_speed };
+
   printf("camera settings:\n");
-  iso_level iso = {settings.iso};
   printf("\tiso: %s\n", to_string(iso).c_str());
-  printf("\tshutter_speed: %s%.1fs\n", settings.one_div_shutter_speed ? "1/" : "", static_cast<double>(settings.shutter_speed) / 1000.0);
+  printf("\tshutter_speed: %s\n", to_string(speed));
   printf("\taperture: %s\n", to_string(settings.aperture).c_str());
   printf("\twhite_balance: %s\n", to_string(settings.white_balance));
   printf("\tfilm_simulation_mode: %s\n", to_string(settings.film_simulation));
@@ -216,7 +245,6 @@ void print(camera_settings const& settings) {
   printf("\tbattery_level: %s\n", to_string(settings.battery));
   printf("\t%s\n", to_string(settings.focus_point).c_str());
   printf("\t%s\n", to_string(settings.image).c_str());
-  iso_level movie_iso = {settings.movie_iso};
   printf("\tmovie_iso: %s\n", to_string(movie_iso).c_str());
   printf("\tflash: %s\n", to_string(settings.flash));
   printf("\tself_timer: %s\n", to_string(settings.self_timer));

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -59,7 +59,8 @@ void print(std::map<property_codes, uint32_t> const& settings) {
         auto const &value = s.second;
 
         if (! property_strings.count(key)) {
-            printf("\t%s: %s\n", property_strings[property_unknown], hex_format(&key, 2).c_str());
+            printf("\t%s (%s): %s\n", property_strings[property_unknown],
+                   hex_format(&key, 2).c_str(), hex_format(&value, 4).c_str());
             continue;
         }
 
@@ -80,8 +81,10 @@ void print(std::map<property_codes, uint32_t> const& settings) {
             printf("%.1f\n", static_cast<double>(value) / 1000.0);
         } else if (key == property_movie_remaining_time || key == property_image_space_sd) {
             printf("%d\n", value);
-        } else {
+        } else if (property_value_strings[key].count(value)) {
             printf("%s\n", property_value_strings[key][value]);
+        } else {
+            printf("%s\n", property_value_strings[property_unknown][0]);
         }
     }
 }

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -78,7 +78,7 @@ void print(std::map<property_codes, uint32_t> const& settings) {
             f_number aperture = value;
             printf("%s\n", to_string(aperture).c_str());
         } else if (key == property_exposure_compensation) {
-            printf("%.1f\n", static_cast<double>(value) / 1000.0);
+            printf("%.1f\n", static_cast<double>(static_cast<int16_t>(value)) / 1000.0);
         } else if (key == property_movie_remaining_time || key == property_image_space_sd) {
             printf("%d\n", value);
         } else if (property_value_strings[key].count(value)) {

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -251,12 +251,13 @@ void print(camera_settings const& settings) {
   printf("\tfilm_simulation_mode: %s\n", to_string(settings.film_simulation));
   printf("\texposure_compensation: %.1f\n", static_cast<double>(settings.exposure_compensation) / 1000.0);
   printf("\tbattery_level: %s\n", to_string(settings.battery));
+  printf("\tfocus_mode: %s\n", to_string(settings.focus));
   printf("\t%s\n", to_string(settings.focus_point).c_str());
+  printf("\tfocus_lock: %s\n", settings.focus_lock ? "on":"off");
   printf("\t%s\n", to_string(settings.image).c_str());
   printf("\tmovie_iso: %s\n", to_string(movie_iso).c_str());
   printf("\tflash: %s\n", to_string(settings.flash));
   printf("\tself_timer: %s\n", to_string(settings.self_timer));
-  printf("\tfocus_mode: %s\n", to_string(settings.focus));
   printf("\tmovie_hd_remaining_time: %ds\n", settings.movie_hd_remaining_time);
   printf("\tshooting_mode: %s\n", to_string(settings.shooting));
   printf("\tdevice_error: %d\n", settings.device_error);

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -192,8 +192,12 @@ std::string to_string(auto_focus_point const& focus_point) {
 
 std::string to_string(image_settings const& image) {
   return string_format(
-      "image_settings: image_format=%s, jpeg_quality=%s, jpeg_size=%s, "
-      "jpeg_aspect=%s, space_on_sdcard=%u",
+      "image_settings:\n"
+      "\t\timage_format = %s\n"
+      "\t\tjpeg_quality = %s\n"
+      "\t\tjpeg_size = %s\n"
+      "\t\tjpeg_aspect = %s\n"
+      "\t\tspace_on_sdcard = %u",
       to_string(image.format), to_string(image.quality), to_string(image.size),
       to_string(image.aspect),
       static_cast<unsigned int>(image.space_on_sdcard));
@@ -207,11 +211,19 @@ void print(camera_settings const& settings) {
   printf("\taperture: %s\n", to_string(settings.aperture).c_str());
   printf("\twhite_balance: %s\n", to_string(settings.white_balance));
   printf("\tfilm_simulation_mode: %s\n", to_string(settings.film_simulation));
-  printf("\texposure: %.1f\n", static_cast<double>(settings.exposure) / 1000.0);
+  printf("\texposure_compensation: %.1f\n", static_cast<double>(settings.exposure_compensation) / 1000.0);
   printf("\tshutter_type: %s\n", to_string(settings.shutter));
-  printf("\tbattery_level: %d\n", settings.battery_level);
+  printf("\tbattery_level: %s\n", to_string(settings.battery));
   printf("\t%s\n", to_string(settings.focus_point).c_str());
   printf("\t%s\n", to_string(settings.image).c_str());
+  iso_level movie_iso = {settings.movie_iso};
+  printf("\tmovie_iso: %s\n", to_string(movie_iso).c_str());
+  printf("\tflash: %s\n", to_string(settings.flash));
+  printf("\tself_timer: %s\n", to_string(settings.self_timer));
+  printf("\tfocus_mode: %s\n", to_string(settings.focus));
+  printf("\tmovie_hd_remaining_time: %ss\n", to_string(settings.movie_hd_remaining_time).c_str());
+  printf("\tshooting_mode: %s\n", to_string(settings.shooting));
+  printf("\tdevice_error: %d\n", settings.device_error);
 }
 
 }  // namespace fcwt

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -56,12 +56,12 @@ double ss_to_microsec(uint32_t raw_speed) {
     return 1000.0 * static_cast<double>(raw_speed);
 }
 
-void print(std::map<property_codes, uint32_t> const& settings) {
+void print(current_properties& settings) {
     printf("camera settings:\n");
 
-    for (auto const &s : settings) {
-        auto const &key   = s.first;
-        auto const &value = s.second;
+    for (size_t i = 0; i < settings.camera_order.size(); ++i) {
+        auto const &key   = settings.camera_order[i];
+        auto const &value = settings.values[key];
 
         if (! property_strings.count(key)) {
             printf("\t%s (%s): %s\n", property_strings[property_unknown],

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -7,9 +7,6 @@
 
 namespace fcwt {
 
-#define CASE_RETURN_ENUM_TO_STRING(x) case x: return #x;
-#define CASE_ASSIGN_AND_BREAK(r, x) case x: r = x; break
-
 std::string to_string(iso_level iso) {
     auto const lvl = iso.value;
     char const* flag = "";
@@ -23,210 +20,27 @@ std::string to_string(iso_level iso) {
     else if (lvl & iso_flag_emulated)
         flag = "(emulated)";
 
-    return string_format("%12d %s", lvl & iso_value_mask, flag);
+    return string_format("%6d %s", lvl & iso_value_mask, flag);
 }
 
 char const* to_string(shutter_speed speed) {
-    bool subsecond = bool(speed.value & shutter_flag_subsecond);
-    double out = static_cast<double>(speed.value & shutter_value_mask) / 1000.0;
+    bool subsecond = bool(speed & shutter_flag_subsecond);
+    double out = static_cast<double>(speed & shutter_value_mask) / 1000.0;
     if (subsecond) 
         return string_format("1/%.1fs", out).c_str();
     else
         return string_format("%.1fs", out).c_str();
 }
 
-char const* to_string(image_format const format) {
-  switch (format) {
-    CASE_RETURN_ENUM_TO_STRING(image_format_jpeg);
-    CASE_RETURN_ENUM_TO_STRING(image_format_raw_and_jpeg);
-  }
-  FCWT_UNREACHABLE;
-}
-
-char const* to_string(jpeg_quality const quality) {
-  switch (quality) {
-    CASE_RETURN_ENUM_TO_STRING(jpeg_quality_fine);
-    CASE_RETURN_ENUM_TO_STRING(jpeg_quality_normal);
-  }
-  FCWT_UNREACHABLE;
-}
-
-char const* to_string(jpeg_size const size) {
-  switch (size) {
-    CASE_RETURN_ENUM_TO_STRING(jpeg_size_s);
-    CASE_RETURN_ENUM_TO_STRING(jpeg_size_m);
-    CASE_RETURN_ENUM_TO_STRING(jpeg_size_l);
-  }
-  FCWT_UNREACHABLE;
-}
-
-char const* to_string(jpeg_aspect const aspect) {
-  switch (aspect) {
-    CASE_RETURN_ENUM_TO_STRING(jpeg_aspect_3_by_2);
-    CASE_RETURN_ENUM_TO_STRING(jpeg_aspect_16_by_9);
-    CASE_RETURN_ENUM_TO_STRING(jpeg_aspect_1_by_1);
-  }
-  FCWT_UNREACHABLE;
-}
-
-char const* to_string(film_simulation_mode const film_simulation) {
-  switch (film_simulation) {
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_provia);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_velvia);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_astia);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_sepia);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_pro_neg_hi);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_pro_neg_std);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome_y_filter);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome_r_filter);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome_g_filter);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_classic_chrome);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_acros);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_acros_y);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_acros_r);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_acros_g);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_eterna);
-  }
-  FCWT_UNREACHABLE;
-}
-
-char const* to_string(shutter_type shutter)
-{
-  switch (shutter) {
-    CASE_RETURN_ENUM_TO_STRING(mechanical_shutter);
-    CASE_RETURN_ENUM_TO_STRING(electronic_shutter);
-  }
-  FCWT_UNREACHABLE; 
-}
-
-char const* to_string(recording_mode mode)
-{
-  switch (mode) {
-    CASE_RETURN_ENUM_TO_STRING(movie_button_unavailable);
-    CASE_RETURN_ENUM_TO_STRING(movie_button_available);
-  }
-  FCWT_UNREACHABLE; 
-}
-
-char const* to_string(shooting_mode mode)
-{
-  switch (mode) {
-    CASE_RETURN_ENUM_TO_STRING(manual_mode);
-    CASE_RETURN_ENUM_TO_STRING(program_mode);
-    CASE_RETURN_ENUM_TO_STRING(aperture_priority_mode);
-    CASE_RETURN_ENUM_TO_STRING(shutter_priority_mode);
-    CASE_RETURN_ENUM_TO_STRING(auto_mode);
-  }
-  FCWT_UNREACHABLE; 
-}
-
-char const* to_string(battery_level level)
-{
-  switch (level) {
-    CASE_RETURN_ENUM_TO_STRING(critical_battery);
-    CASE_RETURN_ENUM_TO_STRING(one_bar_battery);
-    CASE_RETURN_ENUM_TO_STRING(two_bar_battery);
-    CASE_RETURN_ENUM_TO_STRING(full_battery);
-  }
-  FCWT_UNREACHABLE; 
-}
-
-char const* to_string(focus_mode mode)
-{
-  switch (mode) {
-    CASE_RETURN_ENUM_TO_STRING(manual_focus);
-    CASE_RETURN_ENUM_TO_STRING(single_autofocus);
-    CASE_RETURN_ENUM_TO_STRING(continuous_autofocus);
-  }
-  FCWT_UNREACHABLE; 
-}
-
-char const* to_string(timer_mode mode)
-{
-  switch (mode) {
-    CASE_RETURN_ENUM_TO_STRING(timer_off);
-    CASE_RETURN_ENUM_TO_STRING(timer_1sec);
-    CASE_RETURN_ENUM_TO_STRING(timer_2sec);
-    CASE_RETURN_ENUM_TO_STRING(timer_5sec);
-    CASE_RETURN_ENUM_TO_STRING(timer_10sec);
-  }
-  FCWT_UNREACHABLE; 
-}
-
-char const* to_string(white_balance_mode const white_balance) {
-  switch (white_balance) {
-    CASE_RETURN_ENUM_TO_STRING(white_balance_auto);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_custom);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_temperature);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_fine);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_shade);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_fluorescent_1);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_fluorescent_2);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_fluorescent_3);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_incandescent);
-    CASE_RETURN_ENUM_TO_STRING(white_balance_underwater);
-  }
-  FCWT_UNREACHABLE;
-}
-
-char const* to_string(flash_mode const flash) {
-  switch (flash) {
-    CASE_RETURN_ENUM_TO_STRING(flash_auto);
-    CASE_RETURN_ENUM_TO_STRING(flash_off);
-    CASE_RETURN_ENUM_TO_STRING(flash_fill);
-    CASE_RETURN_ENUM_TO_STRING(flash_redeye_auto);
-    CASE_RETURN_ENUM_TO_STRING(flash_redeye_fill);
-    CASE_RETURN_ENUM_TO_STRING(flash_external_sync);
-    CASE_RETURN_ENUM_TO_STRING(flash_on);
-    CASE_RETURN_ENUM_TO_STRING(flash_redeye);
-    CASE_RETURN_ENUM_TO_STRING(flash_redeye_on);
-    CASE_RETURN_ENUM_TO_STRING(flash_redeye_sync);
-    CASE_RETURN_ENUM_TO_STRING(flash_redeye_rear);
-    CASE_RETURN_ENUM_TO_STRING(flash_slow_sync);
-    CASE_RETURN_ENUM_TO_STRING(flash_rear_sync);
-    CASE_RETURN_ENUM_TO_STRING(flash_commander);
-    CASE_RETURN_ENUM_TO_STRING(flash_disable);
-    CASE_RETURN_ENUM_TO_STRING(flash_enable);
-  }
-  FCWT_UNREACHABLE;
-}
-
-bool parse_white_balance_mode(uint16_t const value, white_balance_mode& mode) {
-  switch (value) {
-  default:
-    return false;
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_auto);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_fine);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_custom);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_temperature);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_shade);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_fluorescent_1);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_fluorescent_2);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_fluorescent_3);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_incandescent);
-    CASE_ASSIGN_AND_BREAK(mode, white_balance_underwater);
-  }
-  return true;
-}
-
 std::string to_string(auto_focus_point const& focus_point) {
-  return string_format("auto_focus_point: (%d, %d)",
-                       static_cast<int>(focus_point.x),
-                       static_cast<int>(focus_point.y));
+  return string_format("(%d, %d)", focus_point.x, focus_point.y);
 }
 
-std::string to_string(image_settings const& image) {
-  return string_format(
-      "image_settings:\n"
-      "\t\timage_format = %s\n"
-      "\t\tjpeg_quality = %s\n"
-      "\t\tjpeg_size = %s\n"
-      "\t\tjpeg_aspect = %s\n"
-      "\t\tspace_on_sdcard = %u",
-      to_string(image.format), to_string(image.quality), to_string(image.size),
-      to_string(image.aspect),
-      static_cast<unsigned int>(image.space_on_sdcard));
+std::string to_string(f_number aperture) {
+  if (aperture)
+    return string_format("%.1ff", static_cast<double>(aperture) / 100.0);
+  else
+    return "Auto";
 }
 
 double ss_to_microsec(uint32_t raw_speed) {
@@ -237,30 +51,39 @@ double ss_to_microsec(uint32_t raw_speed) {
     return 1000.0 * static_cast<double>(raw_speed);
 }
 
-void print(camera_settings const& settings) {
-  iso_level iso = { settings.iso };
-  iso_level movie_iso = { settings.movie_iso };
-  shutter_speed speed { settings.shutter.speed };
+void print(std::map<property_codes, uint32_t> const& settings) {
+    printf("camera settings:\n");
 
-  printf("camera settings:\n");
-  printf("\tiso: %s\n", to_string(iso).c_str());
-  printf("\taperture: %s\n", to_string(settings.aperture).c_str());
-  printf("\tshutter_speed: %s\n", to_string(speed));
-  printf("\tshutter_type: %s\n", to_string(settings.shutter.type));
-  printf("\twhite_balance: %s\n", to_string(settings.white_balance));
-  printf("\tfilm_simulation_mode: %s\n", to_string(settings.film_simulation));
-  printf("\texposure_compensation: %.1f\n", static_cast<double>(settings.exposure_compensation) / 1000.0);
-  printf("\tbattery_level: %s\n", to_string(settings.battery));
-  printf("\tfocus_mode: %s\n", to_string(settings.focus));
-  printf("\t%s\n", to_string(settings.focus_point).c_str());
-  printf("\tfocus_lock: %s\n", settings.focus_lock ? "on":"off");
-  printf("\t%s\n", to_string(settings.image).c_str());
-  printf("\tmovie_iso: %s\n", to_string(movie_iso).c_str());
-  printf("\tflash: %s\n", to_string(settings.flash));
-  printf("\tself_timer: %s\n", to_string(settings.self_timer));
-  printf("\tmovie_hd_remaining_time: %ds\n", settings.movie_hd_remaining_time);
-  printf("\tshooting_mode: %s\n", to_string(settings.shooting));
-  printf("\tdevice_error: %d\n", settings.device_error);
+    for (auto const &s : settings) {
+        auto const &key   = s.first;
+        auto const &value = s.second;
+
+        if (! property_strings.count(key)) {
+            printf("\t%s: %s\n", property_strings[property_unknown], hex_format(&key, 2).c_str());
+            continue;
+        }
+
+        printf("\t%s: ", property_strings[key]);
+        if (key == property_iso || key == property_movie_iso) {
+            iso_level const iso { value };
+            printf("%s\n", to_string(iso).c_str());
+        } else if (key == property_shutter_speed) {
+            shutter_speed const spd { value };
+            printf(" %s\n", to_string(spd));
+        } else if (key == property_focus_point) {
+            auto_focus_point point = value;
+            printf("%s\n", to_string(point).c_str());
+        } else if (key == property_aperture) {
+            f_number aperture = value;
+            printf("%s\n", to_string(aperture).c_str());
+        } else if (key == property_exposure_compensation) {
+            printf("%.1f\n", static_cast<double>(value) / 1000.0);
+        } else if (key == property_movie_remaining_time || key == property_image_space_sd) {
+            printf("%d\n", value);
+        } else {
+            printf("%s\n", property_value_strings[key][value]);
+        }
+    }
 }
 
 }  // namespace fcwt

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -37,7 +37,9 @@ std::string to_string(auto_focus_point const& focus_point) {
 }
 
 std::string to_string(f_number aperture) {
-  if (aperture)
+  if (aperture.value == 0xffff)
+    return "---";
+  else if (aperture)
     return string_format("%.1ff", static_cast<double>(aperture) / 100.0);
   else
     return "Auto";

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -24,6 +24,9 @@ std::string to_string(iso_level iso) {
 }
 
 char const* to_string(shutter_speed speed) {
+    if (static_cast<int32_t>(speed.value) == -1)
+        return "----";
+
     bool subsecond = bool(speed & shutter_flag_subsecond);
     double out = static_cast<double>(speed & shutter_value_mask) / 1000.0;
     if (subsecond) 

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -7,9 +7,8 @@
 
 namespace fcwt {
 
-#define CASE_RETURN_ENUM_TO_STRING(x) \
-  case x:                             \
-    return #x
+#define CASE_RETURN_ENUM_TO_STRING(x) case x: return #x;
+#define CASE_ASSIGN_AND_BREAK(r, x) case x: r = x; break
 
 char const* to_string(image_format const format) {
   switch (format) {
@@ -47,17 +46,22 @@ char const* to_string(jpeg_aspect const aspect) {
 
 char const* to_string(film_simulation_mode const film_simulation) {
   switch (film_simulation) {
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_standard);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_vivid);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_soft);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_classic_chrome);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_provia);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_velvia);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_astia);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_sepia);
     CASE_RETURN_ENUM_TO_STRING(film_simulation_pro_neg_hi);
     CASE_RETURN_ENUM_TO_STRING(film_simulation_pro_neg_std);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome);
     CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome_y_filter);
     CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome_r_filter);
     CASE_RETURN_ENUM_TO_STRING(film_simulation_monochrome_g_filter);
-    CASE_RETURN_ENUM_TO_STRING(film_simulation_sepia);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_classic_chrome);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_acros);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_acros_y);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_acros_r);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_acros_g);
+    CASE_RETURN_ENUM_TO_STRING(film_simulation_eterna);
   }
   FCWT_UNREACHABLE;
 }
@@ -67,6 +71,60 @@ char const* to_string(shutter_type shutter)
   switch (shutter) {
     CASE_RETURN_ENUM_TO_STRING(mechanical_shutter);
     CASE_RETURN_ENUM_TO_STRING(electronic_shutter);
+  }
+  FCWT_UNREACHABLE; 
+}
+
+char const* to_string(recording_mode mode)
+{
+  switch (mode) {
+    CASE_RETURN_ENUM_TO_STRING(movie_button_unavailable);
+    CASE_RETURN_ENUM_TO_STRING(movie_button_available);
+  }
+  FCWT_UNREACHABLE; 
+}
+
+char const* to_string(shooting_mode mode)
+{
+  switch (mode) {
+    CASE_RETURN_ENUM_TO_STRING(manual_mode);
+    CASE_RETURN_ENUM_TO_STRING(program_mode);
+    CASE_RETURN_ENUM_TO_STRING(aperture_priority_mode);
+    CASE_RETURN_ENUM_TO_STRING(shutter_priority_mode);
+    CASE_RETURN_ENUM_TO_STRING(auto_mode);
+  }
+  FCWT_UNREACHABLE; 
+}
+
+char const* to_string(battery_level level)
+{
+  switch (level) {
+    CASE_RETURN_ENUM_TO_STRING(critical_battery);
+    CASE_RETURN_ENUM_TO_STRING(one_bar_battery);
+    CASE_RETURN_ENUM_TO_STRING(two_bar_battery);
+    CASE_RETURN_ENUM_TO_STRING(full_battery);
+  }
+  FCWT_UNREACHABLE; 
+}
+
+char const* to_string(focus_mode mode)
+{
+  switch (mode) {
+    CASE_RETURN_ENUM_TO_STRING(manual_focus);
+    CASE_RETURN_ENUM_TO_STRING(single_autofocus);
+    CASE_RETURN_ENUM_TO_STRING(continuous_autofocus);
+  }
+  FCWT_UNREACHABLE; 
+}
+
+char const* to_string(timer_mode mode)
+{
+  switch (mode) {
+    CASE_RETURN_ENUM_TO_STRING(timer_off);
+    CASE_RETURN_ENUM_TO_STRING(timer_1sec);
+    CASE_RETURN_ENUM_TO_STRING(timer_2sec);
+    CASE_RETURN_ENUM_TO_STRING(timer_5sec);
+    CASE_RETURN_ENUM_TO_STRING(timer_10sec);
   }
   FCWT_UNREACHABLE; 
 }
@@ -87,7 +145,26 @@ char const* to_string(white_balance_mode const white_balance) {
   FCWT_UNREACHABLE;
 }
 
-#define CASE_ASSIGN_AND_BREAK(r, x) case x: r = x; break
+char const* to_string(flash_mode const flash) {
+  switch (flash) {
+    CASE_RETURN_ENUM_TO_STRING(flash_auto);
+    CASE_RETURN_ENUM_TO_STRING(flash_off);
+    CASE_RETURN_ENUM_TO_STRING(flash_redeye_auto);
+    CASE_RETURN_ENUM_TO_STRING(flash_redeye_fill);
+    CASE_RETURN_ENUM_TO_STRING(flash_external_sync);
+    CASE_RETURN_ENUM_TO_STRING(flash_on);
+    CASE_RETURN_ENUM_TO_STRING(flash_redeye);
+    CASE_RETURN_ENUM_TO_STRING(flash_redeye_on);
+    CASE_RETURN_ENUM_TO_STRING(flash_redeye_sync);
+    CASE_RETURN_ENUM_TO_STRING(flash_redeye_rear);
+    CASE_RETURN_ENUM_TO_STRING(flash_slow_sync);
+    CASE_RETURN_ENUM_TO_STRING(flash_rear_sync);
+    CASE_RETURN_ENUM_TO_STRING(flash_commander);
+    CASE_RETURN_ENUM_TO_STRING(flash_disable);
+    CASE_RETURN_ENUM_TO_STRING(flash_enable);
+  }
+  FCWT_UNREACHABLE;
+}
 
 bool parse_white_balance_mode(uint16_t const value, white_balance_mode& mode) {
   switch (value) {

--- a/lib/src/settings.cpp
+++ b/lib/src/settings.cpp
@@ -175,6 +175,7 @@ char const* to_string(flash_mode const flash) {
   switch (flash) {
     CASE_RETURN_ENUM_TO_STRING(flash_auto);
     CASE_RETURN_ENUM_TO_STRING(flash_off);
+    CASE_RETURN_ENUM_TO_STRING(flash_fill);
     CASE_RETURN_ENUM_TO_STRING(flash_redeye_auto);
     CASE_RETURN_ENUM_TO_STRING(flash_redeye_fill);
     CASE_RETURN_ENUM_TO_STRING(flash_external_sync);
@@ -249,7 +250,7 @@ void print(camera_settings const& settings) {
   printf("\tflash: %s\n", to_string(settings.flash));
   printf("\tself_timer: %s\n", to_string(settings.self_timer));
   printf("\tfocus_mode: %s\n", to_string(settings.focus));
-  printf("\tmovie_hd_remaining_time: %ss\n", to_string(settings.movie_hd_remaining_time).c_str());
+  printf("\tmovie_hd_remaining_time: %ds\n", settings.movie_hd_remaining_time);
   printf("\tshooting_mode: %s\n", to_string(settings.shooting));
   printf("\tdevice_error: %d\n", settings.device_error);
 }

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -184,7 +184,7 @@ int main(int const argc, char const* argv[]) {
 #ifdef WITH_OPENCV
   std::thread imageStreamCVThread;
 #endif
-  camera_capabilities caps = {};
+  std::vector<capability> caps;
 
   std::string line;
   while (getline(line)) {

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -185,7 +185,7 @@ int main(int const argc, char const* argv[]) {
   std::thread imageStreamCVThread;
 #endif
   std::vector<capability> caps;
-  std::map<property_codes, uint32_t> settings;
+  current_properties settings;
 
   std::string line;
   while (getline(line)) {
@@ -252,18 +252,18 @@ int main(int const argc, char const* argv[]) {
         if (splitLine.size() > 1) {
           uint32_t const aperture = static_cast<uint32_t>(std::stod(splitLine[1]) * 100.0);
           if (aperture > 0 && aperture < 6400 && 
-              current_settings(sockfd, settings) && settings[property_aperture] > 0 &&
-              aperture != settings[property_aperture]) {
-            const fnumber_update_direction direction = aperture < settings[property_aperture] ? fnumber_decrement : fnumber_increment;
+              current_settings(sockfd, settings) && settings.values[property_aperture] > 0 &&
+              aperture != settings.values[property_aperture]) {
+            const fnumber_update_direction direction = aperture < settings.values[property_aperture] ? fnumber_decrement : fnumber_increment;
             uint32_t last_aperture = 0;
             do {
-              last_aperture = settings[property_aperture];
+              last_aperture = settings.values[property_aperture];
               if (!update_setting(sockfd, direction))
                 break;
             } while(current_settings(sockfd, settings) && 
-                    settings[property_aperture] != last_aperture && 
-                    aperture != settings[property_aperture] &&
-                    direction == (aperture < settings[property_aperture] ? fnumber_decrement : fnumber_increment));
+                    settings.values[property_aperture] != last_aperture && 
+                    aperture != settings.values[property_aperture] &&
+                    direction == (aperture < settings.values[property_aperture] ? fnumber_decrement : fnumber_increment));
             print(settings);
           } 
         }
@@ -305,18 +305,18 @@ int main(int const argc, char const* argv[]) {
           int res = std::sscanf(splitLine[1].c_str(), "%lf/%lf", &nom, &denom);
           if (res > 0) {
             double new_speed = (res == 1 ? nom : nom / denom) * 1000000.0;
-            if (current_settings(sockfd, settings) && settings[property_shutter_speed] > 0 &&
-                new_speed != ss_to_microsec(settings[property_shutter_speed])) {
-              const ss_update_direction direction = new_speed < ss_to_microsec(settings[property_shutter_speed]) ? ss_increment : ss_decrement;
+            if (current_settings(sockfd, settings) && settings.values[property_shutter_speed] > 0 &&
+                new_speed != ss_to_microsec(settings.values[property_shutter_speed])) {
+              const ss_update_direction direction = new_speed < ss_to_microsec(settings.values[property_shutter_speed]) ? ss_increment : ss_decrement;
               uint64_t last_speed = 0;
               do {
-                last_speed = ss_to_microsec(settings[property_shutter_speed]);
+                last_speed = ss_to_microsec(settings.values[property_shutter_speed]);
                 if (!update_setting(sockfd, direction))
                   break;
               } while(current_settings(sockfd, settings) &&
-                      ss_to_microsec(settings[property_shutter_speed]) != last_speed &&
-                      new_speed != ss_to_microsec(settings[property_shutter_speed]) &&
-                      direction == (new_speed < ss_to_microsec(settings[property_shutter_speed]) ? ss_increment : ss_decrement));
+                      ss_to_microsec(settings.values[property_shutter_speed]) != last_speed &&
+                      new_speed != ss_to_microsec(settings.values[property_shutter_speed]) &&
+                      direction == (new_speed < ss_to_microsec(settings.values[property_shutter_speed]) ? ss_increment : ss_decrement));
               print(settings);
             }
           }
@@ -341,17 +341,17 @@ int main(int const argc, char const* argv[]) {
       case command::set_exposure_compensation: {
         if (splitLine.size() > 1) {
           uint32_t const exp = static_cast<uint32_t>(std::stod(splitLine[1]) * 1000.0);
-          if (current_settings(sockfd, settings) && exp != settings[property_exposure_compensation]) {
-            const exp_update_direction direction = exp < settings[property_exposure_compensation] ? exp_decrement : exp_increment;
+          if (current_settings(sockfd, settings) && exp != settings.values[property_exposure_compensation]) {
+            const exp_update_direction direction = exp < settings.values[property_exposure_compensation] ? exp_decrement : exp_increment;
             uint32_t last_exp = 0;
             do {
-              last_exp = settings[property_exposure_compensation];
+              last_exp = settings.values[property_exposure_compensation];
               if (!update_setting(sockfd, direction))
                 break;
             } while(current_settings(sockfd, settings) && 
-                    settings[property_exposure_compensation] != last_exp && 
-                    exp != settings[property_exposure_compensation] &&
-                    direction == (exp < settings[property_exposure_compensation] ? exp_decrement : exp_increment));
+                    settings.values[property_exposure_compensation] != last_exp && 
+                    exp != settings.values[property_exposure_compensation] &&
+                    direction == (exp < settings.values[property_exposure_compensation] ? exp_decrement : exp_increment));
             print(settings);
           } 
         }

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -284,29 +284,29 @@ int main() {
 
       case command::set_shutter_speed: {
         if (splitLine.size() > 1) {
-          std::size_t pos = 0;
           double nom, denom;
           int res = std::sscanf(splitLine[1].c_str(), "%lf/%lf", &nom, &denom);
           if (res > 0) {
-            const uint64_t shutter_speed_microsec = (res == 1 ? nom : nom / denom) * 1000000.0;
+            const uint64_t new_speed = (res == 1 ? nom : nom / denom) * 1000000.0;
             camera_settings settings;
-            if (current_settings(sockfd, settings) && settings.shutter_speed > 0 &&
-                shutter_speed_microsec != shutter_speed_microseconds(settings)) {
-              const shutter_speed_stop change = shutter_speed_microsec < shutter_speed_microseconds(settings) ? shutter_speed_one_stop_faster : shutter_speed_one_stop_slower;
-              uint64_t last_shutter_speed = 0;
+            if (current_settings(sockfd, settings) && settings.shutter.speed > 0 &&
+                new_speed != ss_to_microsec(settings.shutter.speed)) {
+              const shutter_speed_stop change = new_speed < ss_to_microsec(settings.shutter.speed) ? shutter_speed_one_stop_faster : shutter_speed_one_stop_slower;
+              uint64_t last_speed = 0;
               do {
-                last_shutter_speed = shutter_speed_microseconds(settings);
+                last_speed = ss_to_microsec(settings.shutter.speed);
                 if (!update_setting(sockfd, change))
                   break;
-              } while(current_settings(sockfd, settings) && 
-                      shutter_speed_microseconds(settings) != last_shutter_speed && 
-                      shutter_speed_microsec != shutter_speed_microseconds(settings) &&
-                      change == (shutter_speed_microsec < shutter_speed_microseconds(settings) ? shutter_speed_one_stop_faster : shutter_speed_one_stop_slower));
+              } while(current_settings(sockfd, settings) &&
+                      ss_to_microsec(settings.shutter.speed) != last_speed &&
+                      new_speed != ss_to_microsec(settings.shutter.speed) &&
+                      change == (new_speed < ss_to_microsec(settings.shutter.speed) ? shutter_speed_one_stop_faster : shutter_speed_one_stop_slower));
               print(settings);
             }
-          } 
+          }
         }
       } break;
+
       case command::white_balance: {
         if (splitLine.size() > 1) {
           int const wbvalue = std::stoi(splitLine[1], 0, 0);

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -90,6 +90,7 @@ char const* commandStrings[] = {"connect", "shutter", "stream",
                                 "white_balance", "current_settings",
                                 "film_simulation", "timer", "flash",
                                 "exposure_compensation", "set_exposure_compensation",
+                                "focus_point", "unlock_focus",
 #ifdef WITH_OPENCV
                                 "stream_cv",
 #endif
@@ -112,6 +113,8 @@ enum class command {
   flash,
   exposure_compensation,
   set_exposure_compensation,
+  focus_point,
+  unlock_focus,
 #ifdef WITH_OPENCV
   stream_cv,
 #endif
@@ -424,6 +427,38 @@ int main(int const argc, char const* argv[]) {
               print(settings);
           } else {
             log(LOG_ERROR, string_format("Failed to set timer %d", value));
+          }
+        }
+      } break;
+
+      case command::focus_point: {
+        if (splitLine.size() == 3) {
+          auto_focus_point point;
+          point.x = std::stoi(splitLine[1], 0, 0);
+          point.y = std::stoi(splitLine[2], 0, 0);
+          if (point.x * point.y <= 0) {
+            log(LOG_INFO, "Could not parse provided value");
+            break;
+          }
+
+          if (update_setting(sockfd, point)) {
+            camera_settings settings;
+            if (current_settings(sockfd, settings))
+              print(settings);
+          } else {
+            log(LOG_ERROR, string_format("Failed to adjust focus point"));
+          }
+        }
+      } break;
+
+      case command::unlock_focus: {
+        if (splitLine.size() == 1) {
+          if (unlock_focus(sockfd)) {
+            camera_settings settings;
+            if (current_settings(sockfd, settings))
+              print(settings);
+          } else {
+            log(LOG_ERROR, string_format("Failed to unlock focus"));
           }
         }
       } break;

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -83,7 +83,7 @@ void image_stream_main(std::atomic<bool>& flag) {
   }
 }
 
-char const* comamndStrings[] = {"connect", "shutter", "stream",
+char const* commandStrings[] = {"connect", "shutter", "stream",
                                 "info", "set_iso", "set_aperture", "aperture",
                                 "shutter_speed", "set_shutter_speed",
                                 "white_balance", "current_settings",
@@ -113,7 +113,7 @@ enum class command {
 
 static void completion(char const* buf, linenoiseCompletions* lc) {
   for (int i = 0; i < static_cast<int>(command::count); ++i) {
-    char const* const cmd = comamndStrings[i];
+    char const* const cmd = commandStrings[i];
     if (strstr(cmd, buf) == cmd) linenoiseAddCompletion(lc, cmd);
   }
 }
@@ -129,7 +129,7 @@ bool getline(std::string& line) {
 
 command parse_command(std::string const& line) {
   for (int i = 0; i < static_cast<int>(command::count); ++i) {
-    if (line == comamndStrings[i]) return static_cast<command>(i);
+    if (line == commandStrings[i]) return static_cast<command>(i);
   }
 
   return command::unknown;

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -37,7 +37,6 @@ void image_stream_cv_main(std::atomic<bool>& flag) {
 
   if (sockfd3 <= 0) return;
 
-  unsigned int image = 0;
   namedWindow( "Display window", WINDOW_AUTOSIZE );// Create a window for display.
   while (flag) {
     size_t receivedBytes =
@@ -199,9 +198,10 @@ int main(int const argc, char const* argv[]) {
             log(LOG_INFO, "Received camera capabilities");
             print(caps);
             camera_settings settings;
-            if (current_settings(sockfd, settings))
+            if (current_settings(sockfd, settings)) {
               log(LOG_INFO, "Received camera settings");
               print(settings);
+            }
             sockfd2 = connect_to_camera(async_response_server_port);
           }
         } else {
@@ -247,7 +247,7 @@ int main(int const argc, char const* argv[]) {
 
       case command::set_aperture: {
         if (splitLine.size() > 1) {
-          int const aperture = static_cast<int>(std::stod(splitLine[1]) * 100.0);
+          uint32_t const aperture = static_cast<uint32_t>(std::stod(splitLine[1]) * 100.0);
           camera_settings settings;
           if (aperture > 0 && aperture < 6400 && 
               current_settings(sockfd, settings) && settings.aperture.value > 0 &&

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -167,11 +167,8 @@ int main(int const argc, char const* argv[]) {
 
   if (argc > 1) {
     std::string arg = argv[1];
-
-    if (arg == "-l" || arg == "--log-level"){
-      std::stringstream convert(argv[2]);
-      convert >> log_level;
-    }
+    if (arg == "-l" || arg == "--log-level")
+      log_level = std::stoi(argv[2], 0, 0);
   }
 
   log_conf.level = log_level;

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -89,6 +89,7 @@ char const* commandStrings[] = {"connect", "shutter", "stream",
                                 "info", "set_iso", "set_aperture", "aperture",
                                 "shutter_speed", "set_shutter_speed",
                                 "white_balance", "current_settings",
+                                "film_simulation",
 #ifdef WITH_OPENCV
                                 "stream_cv",
 #endif
@@ -106,6 +107,7 @@ enum class command {
   set_shutter_speed,
   white_balance,
   current_settings,
+  film_simulation,
 #ifdef WITH_OPENCV
   stream_cv,
 #endif
@@ -333,6 +335,22 @@ int main(int const argc, char const* argv[]) {
               print(settings);
           } else {
             log(LOG_ERROR, string_format("Failed to set white_balance %d", wbvalue));
+          }
+        }
+      } break;
+
+      case command::film_simulation: {
+        if (splitLine.size() > 1) {
+          int const value = std::stoi(splitLine[1], 0, 0);
+          film_simulation_mode fs = static_cast<film_simulation_mode>(value);
+          log(LOG_DEBUG, string_format("%s (%d)", splitLine[0].c_str(), value));
+
+          if (update_setting(sockfd, fs)) {
+            camera_settings settings;
+            if (current_settings(sockfd, settings))
+              print(settings);
+          } else {
+            log(LOG_ERROR, string_format("Failed to set film simulation %d", value));
           }
         }
       } break;

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -47,7 +47,7 @@ void image_stream_cv_main(std::atomic<bool>& flag) {
 
     if ( decodedImage.data == NULL )
     {
-        LOG_WARN("couldn't decode image");
+        log(LOG_WARN, "couldn't decode image");
     }
     imshow( "Display window", decodedImage );
 

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -26,6 +26,8 @@ using namespace cv;
 
 namespace fcwt {
 
+log_settings log_conf;
+
 #ifdef WITH_OPENCV
 void image_stream_cv_main(std::atomic<bool>& flag) {
   log(LOG_INFO, "image_stream_cv_main");
@@ -151,7 +153,20 @@ std::vector<std::string> split(std::string const& str,
   return result;
 }
 
-int main() {
+int main(int const argc, char const* argv[]) {
+  uint8_t log_level = LOG_INFO;
+
+  if (argc > 1) {
+    std::string arg = argv[1];
+
+    if (arg == "-l" || arg == "--log-level"){
+      std::stringstream convert(argv[2]);
+      convert >> log_level;
+    }
+  }
+
+  log_conf.level = log_level;
+
   /* Set the completion callback. This will be called every time the
    * user uses the <tab> key. */
   linenoiseSetCompletionCallback(completion);
@@ -353,4 +368,4 @@ int main() {
 
 }  // namespace fcwt
 
-int main(const int argc, char const* argv[]) { return fcwt::main(); }
+int main(const int argc, char const* argv[]) { return fcwt::main(argc, argv); }


### PR DESCRIPTION
- Identified more of the camera's properties (settings/capabilities) and re-worked the code handling them.
- Slightly improved logging capabilities:
   The app now accepts a log level flag `-l`, values range from 1 to 5, the higher the number the more verbosity you get.
- Added  a few commands to manage the camera settings:
  + flash: to select flash mode
  + film_simulation
  + focus_point: select which point to focus on
  + focus_unlock: unlock the focus if it's locked. Required for further focus point updates to take effect.
  + timer: select a self timer mode
  + exposure_compensation: similar to the `aperture` and `shutter_speed` commands.
  + set_exposure_compensation: similar to the `set_shutter_speed` and `set_aperture` commands.
- Output more user friendly data
- Minor cleanup and removal of no-longer used functions

There is still a lot of room for improvement and code cleanup though.